### PR TITLE
[4] ProfileImage 컴포넌트에 props를 넣어도 적용되지 않는 이슈 해결 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     ]
   },
   rules: {
-    'no-unused-vars': 0
+    'no-unused-vars': 0,
+    'react/prop-types': 0
   }
 };

--- a/src/components/DetailPost/DetailPost.scss
+++ b/src/components/DetailPost/DetailPost.scss
@@ -19,8 +19,7 @@
   &-desc {
     font-size: 2rem;
   }
-}
-
-.ProfileImage {
-  margin-top: 1.5rem;
+  .profile-image {
+    margin-top: 1.5rem;
+  }
 }

--- a/src/components/ProfileImage/ProfileImage.jsx
+++ b/src/components/ProfileImage/ProfileImage.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import './ProfileImage.scss';
 import { getClassName } from '../../utils/utils';
+import { DEFAULT_PROFILE_IMG_URL } from '../../configs';
 
 const ProfileImage = props => {
   const sizeClassName = getClassName({ props, prefix: 'ProfileImage' });
 
   return (
-    <div className={`ProfileImage ${sizeClassName}`}>
-      <img src="" alt="profile-image" />
-    </div>
+    <img
+      src={props.src || DEFAULT_PROFILE_IMG_URL}
+      alt="profile-image"
+      className={`ProfileImage ${sizeClassName}`}
+    />
   );
 };
 

--- a/src/components/ProfileImage/ProfileImage.jsx
+++ b/src/components/ProfileImage/ProfileImage.jsx
@@ -4,7 +4,7 @@ import { getClassName } from '../../utils/utils';
 import { DEFAULT_PROFILE_IMG_URL } from '../../configs';
 
 const ProfileImage = props => {
-  const { className, src, ...restProps } = props;
+  const { className, src, small, medium, large, ...restProps } = props;
   const sizeClassName = getClassName({ props, prefix: 'profile-image' });
 
   return (

--- a/src/components/ProfileImage/ProfileImage.jsx
+++ b/src/components/ProfileImage/ProfileImage.jsx
@@ -4,13 +4,15 @@ import { getClassName } from '../../utils/utils';
 import { DEFAULT_PROFILE_IMG_URL } from '../../configs';
 
 const ProfileImage = props => {
-  const sizeClassName = getClassName({ props, prefix: 'ProfileImage' });
+  const { className, src, ...restProps } = props;
+  const sizeClassName = getClassName({ props, prefix: 'profile-image' });
 
   return (
     <img
-      src={props.src || DEFAULT_PROFILE_IMG_URL}
+      src={src || DEFAULT_PROFILE_IMG_URL}
       alt="profile-image"
-      className={`ProfileImage ${sizeClassName}`}
+      className={`profile-image ${sizeClassName} ${className}`}
+      {...restProps}
     />
   );
 };

--- a/src/components/ProfileImage/ProfileImage.scss
+++ b/src/components/ProfileImage/ProfileImage.scss
@@ -1,4 +1,4 @@
-.ProfileImage {
+.profile-image {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/configs.js
+++ b/src/configs.js
@@ -1,0 +1,2 @@
+export const DEFAULT_PROFILE_IMG_URL =
+  'https://user-images.githubusercontent.com/42905468/66740814-132e4e00-eeaf-11e9-8132-95c3a5594af0.png';


### PR DESCRIPTION
## 구현내용
- eslint - react/prop-types 룰 해제
- div로 감싸진 중첩구조를 img태그를 단독으로 사용하는 컴포넌트로 수정
  - img가 엘리먼트의 모양에 맞게 나오도록 수정
- props를 spread로 img태그에 넘겨주어 추가적인 props가 적용되도록 수정
- css 클래스명을 규칙에 맞게 수정
  - ProfileImage > profile-image
- DetailPost컴포넌트에 사용된 ProfileImage css 클래스명을 profile-image로 수정

resolved #12 