### PR TITLE
[3] 메인 페이지 구현

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,11 @@ module.exports = function(api) {
 
   const presets = [['@babel/preset-env'], ['@babel/preset-react']];
 
-  const plugins = ['@babel/plugin-transform-runtime', 'react-hot-loader/babel'];
+  const plugins = [
+    '@babel/plugin-transform-runtime',
+    'react-hot-loader/babel',
+    'emotion'
+  ];
 
   return {
     presets,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "npm:@hot-loader/react-dom",
     "react-hot-loader": "^4.12.14",
     "react-naver-map": "^0.0.23",
-    "react-router-dom": "^5.1.0"
+    "react-router-dom": "^5.1.0",
+    "react-spinners": "^0.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,5 +1,6 @@
 .header {
   position: fixed;
+  top: 0;
   display: flex;
   justify-content: space-around;
   align-items: center;
@@ -9,6 +10,7 @@
   background: #fff;
   border: 1px solid #d4d4d4;
   border-radius: 5px;
+  z-index: 1000;
 
   h1 {
     flex: 1;

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,10 +1,12 @@
 .header {
+  position: fixed;
   display: flex;
   justify-content: space-around;
   align-items: center;
   width: 100%;
   height: 8rem;
   padding: 0 2rem;
+  background: #fff;
   border: 1px solid #d4d4d4;
   border-radius: 5px;
 

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -4,12 +4,12 @@ import { Link } from 'react-router-dom';
 import PostItem from '../PostItem/PostItem';
 
 const PostContainer = ({ items, header }) => {
-  const postItems = (items || []).map(e => (
+  const postItems = (items || []).map(item => (
     <Link
-      to={`/post/${e.postId}`}
-      key={e.postId || Math.floor(Math.random() * 10000)}
+      to={`/post/${item.postId}`}
+      key={item.postId || Math.floor(Math.random() * 10000)}
     >
-      <PostItem headerOn={header} {...e}></PostItem>
+      <PostItem headerOn={header} {...item}></PostItem>
     </Link>
   ));
   return (

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import './PostContainer.scss';
+import { Link } from 'react-router-dom';
 import PostItem from '../PostItem/PostItem';
 
 const PostContainer = ({ items, header }) => {
   const postItems = (items || []).map(e => (
-    <PostItem
+    <Link
+      to={`/post/${e.postId}`}
       key={e.postId || Math.floor(Math.random() * 10000)}
-      headerOn={header}
-      {...e}
-    ></PostItem>
+    >
+      <PostItem headerOn={header} {...e}></PostItem>
+    </Link>
   ));
   return (
     <div className="post-container-wrapper">

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -4,8 +4,11 @@ import PostItem from '../PostItem/PostItem';
 
 const PostContainer = props => {
   const postItems = props.items.map(e => (
-    <PostItem key={e.id || Math.floor(Math.random() * 9999)}>
-      {e.title || 'title'}
+    <PostItem
+      key={e.postId || Math.floor(Math.random() * 10000)}
+      url={e.representativePostImage}
+    >
+      {e.postId || 'title'}
     </PostItem>
   ));
   return (

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import './PostContainer.scss';
+import PostItem from '../PostItem/PostItem';
+
+const PostContainer = props => {
+  const postItems = props.items.map(e => (
+    <PostItem key={e.id || Math.floor(Math.random() * 9999)}>
+      {e.title || 'title'}
+    </PostItem>
+  ));
+  return (
+    <div className="post-container-wrapper">
+      <div className="post-container">{postItems}</div>
+    </div>
+  );
+};
+
+export default PostContainer;

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -6,6 +6,7 @@ const PostContainer = props => {
   const postItems = props.items.map(e => (
     <PostItem
       key={e.postId || Math.floor(Math.random() * 10000)}
+      headerOn={props.header}
       {...e}
     ></PostItem>
   ));

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -6,10 +6,8 @@ const PostContainer = props => {
   const postItems = props.items.map(e => (
     <PostItem
       key={e.postId || Math.floor(Math.random() * 10000)}
-      url={e.representativePostImage}
-    >
-      {e.postId || 'title'}
-    </PostItem>
+      {...e}
+    ></PostItem>
   ));
   return (
     <div className="post-container-wrapper">

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import './PostContainer.scss';
 import PostItem from '../PostItem/PostItem';
 
-const PostContainer = props => {
-  const postItems = props.items.map(e => (
+const PostContainer = ({ items, header }) => {
+  const postItems = (items || []).map(e => (
     <PostItem
       key={e.postId || Math.floor(Math.random() * 10000)}
-      headerOn={props.header}
+      headerOn={header}
       {...e}
     ></PostItem>
   ));

--- a/src/components/PostContainer/PostContainer.scss
+++ b/src/components/PostContainer/PostContainer.scss
@@ -1,0 +1,12 @@
+.post-container {
+  display: grid;
+  grid-template-columns: 50% 50%;
+  width: 50rem;
+  padding: 2rem 0;
+
+  &-wrapper {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/src/components/PostContainer/PostContainer.scss
+++ b/src/components/PostContainer/PostContainer.scss
@@ -1,7 +1,7 @@
 .post-container {
   display: grid;
   grid-template-columns: 50% 50%;
-  width: 50rem;
+  width: 80rem;
   padding: 2rem 0;
 
   &-wrapper {

--- a/src/components/PostContainer/PostContainer.scss
+++ b/src/components/PostContainer/PostContainer.scss
@@ -1,8 +1,18 @@
 .post-container {
   display: grid;
+  justify-items: center;
   grid-template-columns: 50% 50%;
-  width: 80rem;
+  row-gap: 6rem;
+  width: 72rem;
   padding: 2rem 0;
+
+  a {
+    color: black;
+    &:hover {
+      text-decoration: none;
+      color: inherit;
+    }
+  }
 
   &-wrapper {
     display: flex;

--- a/src/components/PostItem/PostItem.jsx
+++ b/src/components/PostItem/PostItem.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './PostItem.scss';
+
+const PostItem = props => {
+  return (
+    <div className="post-item" {...props}>
+      {props.children}
+    </div>
+  );
+};
+
+export default PostItem;

--- a/src/components/PostItem/PostItem.jsx
+++ b/src/components/PostItem/PostItem.jsx
@@ -3,7 +3,8 @@ import './PostItem.scss';
 
 const PostItem = props => {
   return (
-    <div className="post-item" {...props}>
+    <div className="post-item">
+      <img src={props.url} alt="" />
       {props.children}
     </div>
   );

--- a/src/components/PostItem/PostItem.jsx
+++ b/src/components/PostItem/PostItem.jsx
@@ -1,11 +1,28 @@
 import React from 'react';
 import './PostItem.scss';
+import ProfileImage from '../ProfileImage/ProfileImage';
 
-const PostItem = props => {
+const PostItem = ({
+  writerImageUrl,
+  writerNickname,
+  representativePostImage,
+  titlePlace,
+  titleCompanion,
+  titleActivity,
+  description
+}) => {
+  const desc = Buffer.from(description).toString();
   return (
     <div className="post-item">
-      <img src={props.url} alt="" />
-      {props.children}
+      <div className="post-item-header">
+        <ProfileImage small src={writerImageUrl} />
+        <span>{writerNickname}</span>
+      </div>
+      <img className="post-item-img" src={representativePostImage} alt="" />
+      <div className="post-item-title">
+        {titlePlace}에서 {titleCompanion}랑 {titleActivity}
+      </div>
+      <div className="post-item-desc">{desc}</div>
     </div>
   );
 };

--- a/src/components/PostItem/PostItem.jsx
+++ b/src/components/PostItem/PostItem.jsx
@@ -9,15 +9,18 @@ const PostItem = ({
   titlePlace,
   titleCompanion,
   titleActivity,
-  description
+  description,
+  headerOn
 }) => {
   const desc = Buffer.from(description).toString();
   return (
     <div className="post-item">
-      <div className="post-item-header">
-        <ProfileImage small src={writerImageUrl} />
-        <span>{writerNickname}</span>
-      </div>
+      {headerOn && (
+        <div className="post-item-header">
+          <ProfileImage small src={writerImageUrl} />
+          <span>{writerNickname}</span>
+        </div>
+      )}
       <img className="post-item-img" src={representativePostImage} alt="" />
       <div className="post-item-title">
         {titlePlace}에서 {titleCompanion}랑 {titleActivity}

--- a/src/components/PostItem/PostItem.scss
+++ b/src/components/PostItem/PostItem.scss
@@ -1,13 +1,37 @@
 .post-item {
-  width: 15rem;
-  height: 15rem;
+  width: 30rem;
   border: 1px solid #d4d4d4;
   border-radius: 5px;
   justify-self: center;
   align-self: center;
   margin: 3rem;
-  img {
+  &:hover {
+    cursor: pointer;
+    box-shadow: 0 0 10px #a0a0a0;
+  }
+
+  &-header {
+    display: flex;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    span {
+      font-size: 2rem;
+      font-weight: bold;
+      padding-left: 1rem;
+    }
+  }
+
+  &-img {
     width: inherit;
     height: inherit;
+  }
+
+  &-title {
+    padding: 1rem 1.5rem 0 1.5rem;
+    font-size: 2rem;
+  }
+  &-desc {
+    padding: 1rem 1.5rem 2rem 1.5rem;
+    font-size: 1.5rem;
   }
 }

--- a/src/components/PostItem/PostItem.scss
+++ b/src/components/PostItem/PostItem.scss
@@ -4,7 +4,6 @@
   border-radius: 5px;
   justify-self: center;
   align-self: center;
-  margin: 3rem;
   &:hover {
     cursor: pointer;
     box-shadow: 0 0 10px #a0a0a0;

--- a/src/components/PostItem/PostItem.scss
+++ b/src/components/PostItem/PostItem.scss
@@ -1,0 +1,9 @@
+.post-item {
+  width: 15rem;
+  height: 15rem;
+  border: 1px solid #d4d4d4;
+  border-radius: 5px;
+  justify-self: center;
+  align-self: center;
+  margin: 3rem;
+}

--- a/src/components/PostItem/PostItem.scss
+++ b/src/components/PostItem/PostItem.scss
@@ -6,4 +6,8 @@
   justify-self: center;
   align-self: center;
   margin: 3rem;
+  img {
+    width: inherit;
+    height: inherit;
+  }
 }

--- a/src/configs.js
+++ b/src/configs.js
@@ -7,3 +7,5 @@ export const VIEWPORT_HEIGHT = Math.max(
   document.documentElement.clientHeight,
   window.innerHeight || 0
 );
+
+export const MAIN_COLOR = '#123abc';

--- a/src/configs.js
+++ b/src/configs.js
@@ -1,2 +1,9 @@
 export const DEFAULT_PROFILE_IMG_URL =
   'https://user-images.githubusercontent.com/42905468/66740814-132e4e00-eeaf-11e9-8132-95c3a5594af0.png';
+
+export const WEB_SERVER_URL = 'http://13.124.93.76';
+
+export const VIEWPORT_HEIGHT = Math.max(
+  document.documentElement.clientHeight,
+  window.innerHeight || 0
+);

--- a/src/hooks/useFetch.jsx
+++ b/src/hooks/useFetch.jsx
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * @param {string} url fetch요청할 url
+ * @param {Object} options fetch함수의 두번째 인자로 전달할 옵션객체
+ * @param {Function} callback fetch받은 data를 상태로 저장할 setState함수
+ */
+const useFetch = (url, options, callback) => {
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch(url, options);
+        if (res instanceof Promise) throw Error('REQUEST FAILED');
+        if (!res.ok) throw Error(`STATUS CODE : ${res.status}`);
+        const json = await res.json();
+        callback(json);
+      } catch (error) {
+        setError(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [url]);
+
+  return { error, loading };
+};
+
+export default useFetch;

--- a/src/hooks/useFetch.jsx
+++ b/src/hooks/useFetch.jsx
@@ -1,4 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
+
+//TODO: 배포시 제거
+const makeDelay = timeInMs => {
+  return new Promise(res => setTimeout(res, timeInMs));
+};
 
 /**
  * @param {string} url fetch요청할 url
@@ -12,6 +17,8 @@ const useFetch = (url, options, callback) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
+        setLoading(true);
+        await makeDelay(2000); //TODO: 배포시 제거
         const res = await fetch(url, options);
         if (res instanceof Promise) throw Error('REQUEST FAILED');
         if (!res.ok) throw Error(`STATUS CODE : ${res.status}`);

--- a/src/pages/DetailPage/DetailPage.scss
+++ b/src/pages/DetailPage/DetailPage.scss
@@ -2,4 +2,5 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-top: 10rem;
 }

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -3,7 +3,9 @@ import './MainPage.scss';
 import Header from '../../components/Header/Header';
 import PostContainer from '../../components/PostContainer/PostContainer';
 import useFetch from '../../hooks/useFetch';
-import { WEB_SERVER_URL, VIEWPORT_HEIGHT } from '../../configs';
+import { css } from '@emotion/core';
+import FadeLoader from 'react-spinners/FadeLoader';
+import { WEB_SERVER_URL, VIEWPORT_HEIGHT, MAIN_COLOR } from '../../configs';
 
 const MainPage = () => {
   const [page, setPage] = useState(1);
@@ -46,9 +48,9 @@ const MainPage = () => {
   };
 
   const isScrollEnd = () => {
-    const scrollY = window.scrollY;
+    const pageYOffset = window.pageYOffset;
     const documentHeight = document.body.offsetHeight; //TODO: 새로운 items를 렌더링 할 때만 값을 캐싱하도록 수정필요
-    const viewportBottomPosition = VIEWPORT_HEIGHT + scrollY;
+    const viewportBottomPosition = VIEWPORT_HEIGHT + pageYOffset;
     const distanceToBottom = documentHeight - viewportBottomPosition;
     return distanceToBottom === 0;
   };
@@ -56,9 +58,24 @@ const MainPage = () => {
   return (
     <div className="main-page">
       <Header />
-      {!loading && <PostContainer items={items} header />}
+      {loading ? (
+        <FadeLoader
+          css={override}
+          sizeUnit={'px'}
+          size={150}
+          color={MAIN_COLOR}
+          loading={loading}
+        />
+      ) : (
+        <PostContainer items={items} header />
+      )}
     </div>
   );
 };
 
 export default MainPage;
+
+const override = css`
+  display: block;
+  margin: 10rem auto;
+`;

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -10,7 +10,7 @@ import { WEB_SERVER_URL, VIEWPORT_HEIGHT, MAIN_COLOR } from '../../configs';
 const MainPage = () => {
   const [page, setPage] = useState(1);
   const [response, setResponse] = useState(null);
-  const items = response ? response.posts : [];
+  const items = response ? response.posts : null;
 
   const { error, loading } = useFetch(
     `${WEB_SERVER_URL}/post?page=${page}`,
@@ -58,17 +58,14 @@ const MainPage = () => {
   return (
     <div className="main-page">
       <Header />
-      {loading ? (
-        <FadeLoader
-          css={override}
-          sizeUnit={'px'}
-          size={150}
-          color={MAIN_COLOR}
-          loading={loading}
-        />
-      ) : (
-        <PostContainer items={items} header />
-      )}
+      {items && <PostContainer items={items} header />}
+      <FadeLoader
+        css={override}
+        sizeUnit={'px'}
+        size={150}
+        color={MAIN_COLOR}
+        loading={loading}
+      />
     </div>
   );
 };

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -56,7 +56,7 @@ const MainPage = () => {
   return (
     <div className="main-page">
       <Header />
-      {!loading && <PostContainer items={items} />}
+      {!loading && <PostContainer items={items} header />}
     </div>
   );
 };

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
 import './MainPage.scss';
+import Header from '../../components/Header/Header';
+import PostContainer from '../../components/PostContainer/PostContainer';
+
+const data = {
+  hasNextPage: true,
+  items: [
+    { title: 'test1' },
+    { title: 'test2' },
+    { title: 'test3' },
+    { title: 'test3' },
+    { title: 'test3' }
+  ]
+};
 
 const MainPage = () => {
+  //const { setInfiniteScroll } = useInfiniteScroll()
   return (
     <div className="main-page">
-      <h1>this is main page</h1>
+      <Header />
+      <PostContainer items={data.items} />
     </div>
   );
 };

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,25 +1,62 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import './MainPage.scss';
 import Header from '../../components/Header/Header';
 import PostContainer from '../../components/PostContainer/PostContainer';
-
-const data = {
-  hasNextPage: true,
-  items: [
-    { title: 'test1' },
-    { title: 'test2' },
-    { title: 'test3' },
-    { title: 'test3' },
-    { title: 'test3' }
-  ]
-};
+import useFetch from '../../hooks/useFetch';
+import { WEB_SERVER_URL, VIEWPORT_HEIGHT } from '../../configs';
 
 const MainPage = () => {
-  //const { setInfiniteScroll } = useInfiniteScroll()
+  const [page, setPage] = useState(1);
+  const [response, setResponse] = useState(null);
+  const items = response ? response.posts : [];
+
+  const { error, loading } = useFetch(
+    `${WEB_SERVER_URL}/post?page=${page}`,
+    {},
+    json => mergeResponse(response, json)
+  );
+
+  const mergeResponse = (prevResponse, response) => {
+    const isFirstFetch = prevResponse === null;
+    if (isFirstFetch) {
+      return setResponse(response);
+    }
+    return setResponse({
+      hasNextPage: response.hasNextPage,
+      posts: [...prevResponse.posts, ...response.posts]
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [response]);
+
+  const handleScroll = () => {
+    if (hasNoMorePage(response)) return;
+    if (isScrollEnd()) {
+      setPage(() => page + 1);
+    }
+  };
+
+  const hasNoMorePage = response => {
+    return response && !response.hasNextPage;
+  };
+
+  const isScrollEnd = () => {
+    const scrollY = window.scrollY;
+    const documentHeight = document.body.offsetHeight; //TODO: 새로운 items를 렌더링 할 때만 값을 캐싱하도록 수정필요
+    const viewportBottomPosition = VIEWPORT_HEIGHT + scrollY;
+    const distanceToBottom = documentHeight - viewportBottomPosition;
+    return distanceToBottom === 0;
+  };
+
   return (
     <div className="main-page">
       <Header />
-      <PostContainer items={data.items} />
+      {!loading && <PostContainer items={items} />}
     </div>
   );
 };

--- a/src/pages/MainPage/MainPage.scss
+++ b/src/pages/MainPage/MainPage.scss
@@ -1,4 +1,7 @@
 .main-page {
+  display: flex;
+  flex-direction: column;
+
   .post-container-wrapper {
     padding-top: 8rem;
   }

--- a/src/pages/MainPage/MainPage.scss
+++ b/src/pages/MainPage/MainPage.scss
@@ -1,2 +1,5 @@
 .main-page {
+  .post-container-wrapper {
+    padding-top: 8rem;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,6 +712,83 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@emotion/cache@^10.0.17":
+  version "10.0.19"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.19.tgz#d258d94d9c707dcadaf1558def968b86bb87ad71"
+  integrity sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==
+  dependencies:
+    "@emotion/sheet" "0.9.3"
+    "@emotion/stylis" "0.8.4"
+    "@emotion/utils" "0.11.2"
+    "@emotion/weak-memoize" "0.2.4"
+
+"@emotion/core@^10.0.15":
+  version "10.0.21"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.21.tgz#2e8398d2b92fd90d4ed6ac4d0b66214971de3458"
+  integrity sha512-U9zbc7ovZ2ceIwbLXYZPJy6wPgnOdTNT4jENZ31ee6v2lojetV5bTbCVk6ciT8G3wQRyVaTTfUCH9WCrMzpRIw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.17"
+    "@emotion/css" "^10.0.14"
+    "@emotion/serialize" "^0.11.10"
+    "@emotion/sheet" "0.9.3"
+    "@emotion/utils" "0.11.2"
+
+"@emotion/css@^10.0.14":
+  version "10.0.14"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.14.tgz#95dacabdd0e22845d1a1b0b5968d9afa34011139"
+  integrity sha512-MozgPkBEWvorcdpqHZE5x1D/PLEHUitALQCQYt2wayf4UNhpgQs2tN0UwHYS4FMy5ROBH+0ALyCFVYJ/ywmwlg==
+  dependencies:
+    "@emotion/serialize" "^0.11.8"
+    "@emotion/utils" "0.11.2"
+    babel-plugin-emotion "^10.0.14"
+
+"@emotion/hash@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.3.tgz#a166882c81c0c6040975dd30df24fae8549bd96f"
+  integrity sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==
+
+"@emotion/memoize@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
+  integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
+
+"@emotion/serialize@^0.11.10", "@emotion/serialize@^0.11.11", "@emotion/serialize@^0.11.8":
+  version "0.11.11"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.11.tgz#c92a5e5b358070a7242d10508143306524e842a4"
+  integrity sha512-YG8wdCqoWtuoMxhHZCTA+egL0RSGdHEc+YCsmiSBPBEDNuVeMWtjEWtGrhUterSChxzwnWBXvzSxIFQI/3sHLw==
+  dependencies:
+    "@emotion/hash" "0.7.3"
+    "@emotion/memoize" "0.7.3"
+    "@emotion/unitless" "0.7.4"
+    "@emotion/utils" "0.11.2"
+    csstype "^2.5.7"
+
+"@emotion/sheet@0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.3.tgz#689f135ecf87d3c650ed0c4f5ddcbe579883564a"
+  integrity sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==
+
+"@emotion/stylis@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.4.tgz#6c51afdf1dd0d73666ba09d2eb6c25c220d6fe4c"
+  integrity sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==
+
+"@emotion/unitless@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
+  integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
+
+"@emotion/utils@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.2.tgz#713056bfdffb396b0a14f1c8f18e7b4d0d200183"
+  integrity sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA==
+
+"@emotion/weak-memoize@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
+  integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
+
 "@restart/context@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@restart/context/-/context-2.1.4.tgz#a99d87c299a34c28bd85bb489cb07bfd23149c02"
@@ -1232,6 +1309,36 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-emotion@^10.0.14:
+  version "10.0.21"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.21.tgz#9ebeb12edeea3e60a5476b0e07c9868605e65968"
+  integrity sha512-03o+T6sfVAJhNDcSdLapgv4IeewcFPzxlvBUVdSf7o5PI57ZSxoDvmy+ZulVWSu+rOWAWkEejNcsb29TuzJHbg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.7.3"
+    "@emotion/memoize" "0.7.3"
+    "@emotion/serialize" "^0.11.11"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
+babel-plugin-macros@^2.0.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz#41f7ead616fc36f6a93180e89697f69f51671181"
+  integrity sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    cosmiconfig "^5.2.0"
+    resolve "^1.10.0"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -1508,6 +1615,25 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -1823,7 +1949,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@^1.1.0:
+convert-source-map@^1.1.0, convert-source-map@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
@@ -1869,6 +1995,16 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cosmiconfig@^5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.1"
+    parse-json "^4.0.0"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -1983,7 +2119,7 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-csstype@^2.2.0, csstype@^2.6.6:
+csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.6:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
   integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
@@ -2372,7 +2508,7 @@ errno@^0.1.3, errno@~0.1.7:
   dependencies:
     prr "~1.0.1"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
@@ -2776,6 +2912,11 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -3394,6 +3535,14 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
+
 import-fresh@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
@@ -3617,6 +3766,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -3814,7 +3968,7 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-json-parse-better-errors@^1.0.2:
+json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
@@ -4845,6 +4999,14 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -5364,6 +5526,13 @@ react-router@5.1.2:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-spinners@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.6.1.tgz#c4f31a1d0e4c85cdb1785a8bdbe17311cf269b0a"
+  integrity sha512-bMCOvwAlzuIDC6Zh69E1EbyKUbvWSl4sMzLXOgnsF4Q/kkAnCNaonWyskMFytbaJSYxBCCOiaeCH2moDJ5y5Pg==
+  dependencies:
+    "@emotion/core" "^10.0.15"
 
 react-transition-group@^4.0.0:
   version "4.3.0"
@@ -6012,7 +6181,7 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=


### PR DESCRIPTION
## 구현 사항
- 메인 페이지에 보여질 PostItem 컴포넌트 작성
  - 프로필 이미지와 유저네임이 나오는 헤더부분은 옵션으로 on/off가능하도록 작성
  - 프로필 페이지에 재사용 가능
- 무한 스크롤 인터렉션 구현
  - 스크롤이벤트 > viewport가 전체 document에서 어디만큼 내려왔는지 y값 체크 > 끝까지 스크롤한 경우 다음 페이지 fetch요청 > fetch도중 로딩스피너 표시 > fetch완료 시 기존 데이터와 합쳐서 렌더링
  - 로딩 스피너 표시 모듈 사용(현재 임의로 딜레이 줘서 스피너 보이도록 작성)
- post item 눌렀을 때 디테일페이지로 연결되도록 라우팅 처리

### 참고 
- 라우팅 처리는 했는데 아직 postId넘겨 받는 코드는 작성하지 않았어요. 8번이슈(#23) 해결하면서 같이 할게요.
---

resolved #11 