### PR TITLE
[8] detail page에 fetch 코드 추가 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@
 - [figma](https://www.figma.com/file/3rjXMNRb7DhheV2cpCu0Ql/interest-sharing-sns?node-id=0%3A1)를 이용해 합의한 기능에 의한 프로토타입을 디자인 합니다.
 
 - Github을 협업에서 사용하는 수준과 유사한 수준으로 경험해보려고 합니다.
-  - 매주 스프린트 회의에서 정해진 개뱔을 분담하여, issue에 등록합니다.
+  - 매주 스프린트 회의에서 정해진 개발을 분담하여, issue로 등록합니다.
   - PR에 대한 코드 리뷰는 최대한 꼼꼼히 진행하며 피드백을 반영한 뒤에 merge 합니다.
   - Project로 각자의 진행 상황을 항상 업데이트 합니다.

--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -5,15 +5,16 @@ import MainPage from './pages/MainPage/MainPage';
 import DetailPage from '../src/pages/DetailPage/DetailPage';
 import ProfileEditPage from '../src/pages/ProfileEditPage/ProfileEditPage';
 
-
-
 const Root = () => {
   return (
     <>
       <Router>
         <Switch>
           <Route exact path="/" render={() => <MainPage />}></Route>
-          <Route path="/post" render={() => <DetailPage />}></Route>
+          <Route
+            path="/post/"
+            render={props => <DetailPage {...props} />}
+          ></Route>
           <Route
             path="/profile-edit"
             render={() => <ProfileEditPage />}

--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -12,8 +12,8 @@ const Root = () => {
         <Switch>
           <Route exact path="/" render={() => <MainPage />}></Route>
           <Route
-            path="/post/"
-            render={props => <DetailPage {...props} />}
+            path="/post/:postId"
+            render={({ match }) => <DetailPage postId={match.params.postId} />}
           ></Route>
           <Route
             path="/profile-edit"

--- a/src/components/DetailPost/DetailPost.jsx
+++ b/src/components/DetailPost/DetailPost.jsx
@@ -8,15 +8,16 @@ const DetailPost = props => {
     titleCompanion,
     titlePlace,
     writerImageURL,
-    writerNickname
+    writerNickname,
+    description
   } = props.data;
 
-  const description = Buffer.from(props.data.description).toString();
+  const desc = Buffer.from(description).toString();
 
   return (
     <div className="detail-post">
       <h1 className="detail-post-title">
-        {titleCompanion}랑 {titlePlace}에서 {titleActivity}
+        {titlePlace}에서 {titleCompanion}랑 {titleActivity}
       </h1>
       <div className="detail-post-content">
         <div className="detail-post-writer-img">
@@ -24,7 +25,7 @@ const DetailPost = props => {
         </div>
         <div>
           <h3 className="detail-post-writer-name">{writerNickname}</h3>
-          <p className="detail-post-desc">{description}</p>
+          <p className="detail-post-desc">{desc}</p>
         </div>
       </div>
     </div>

--- a/src/components/DetailPost/DetailPost.jsx
+++ b/src/components/DetailPost/DetailPost.jsx
@@ -8,8 +8,7 @@ const DetailPost = props => {
     titleCompanion,
     titlePlace,
     writerImageURL,
-    writerNickname,
-    postImageURLs
+    writerNickname
   } = props.data;
 
   const description = Buffer.from(props.data.description).toString();

--- a/src/components/DetailPost/DetailPost.jsx
+++ b/src/components/DetailPost/DetailPost.jsx
@@ -2,21 +2,30 @@ import React from 'react';
 import './DetailPost.scss';
 import ProfileImage from '../ProfileImage/ProfileImage';
 
-const DetailPost = () => {
+const DetailPost = props => {
+  const {
+    titleActivity,
+    titleCompanion,
+    titlePlace,
+    writerImageURL,
+    writerNickname,
+    postImageURLs
+  } = props.data;
+
+  const description = Buffer.from(props.data.description).toString();
+
   return (
     <div className="detail-post">
-      <h1 className="detail-post-title">공공거실에서 친구랑 맥주 한 잔 하기</h1>
+      <h1 className="detail-post-title">
+        {titleCompanion}랑 {titlePlace}에서 {titleActivity}
+      </h1>
       <div className="detail-post-content">
         <div className="detail-post-writer-img">
-          <ProfileImage small></ProfileImage>
+          <ProfileImage small src={writerImageURL}></ProfileImage>
         </div>
         <div>
-          <h3 className="detail-post-writer-name">crazyfish228</h3>
-          <p className="detail-post-desc">
-            {
-              '공공거실에서 친구랑 맥주 한 잔 했더니 너~~~~~~~~~~~~~~~무 기분 좋아요! >_<'
-            }
-          </p>
+          <h3 className="detail-post-writer-name">{writerNickname}</h3>
+          <p className="detail-post-desc">{description}</p>
         </div>
       </div>
     </div>

--- a/src/components/LocationCarousel/LocationCarousel.jsx
+++ b/src/components/LocationCarousel/LocationCarousel.jsx
@@ -6,9 +6,9 @@ const LocationCarousel = ({ data }) => {
   const { postImageURLs } = data;
 
   const makeCarouselItem = imgUrls => {
-    return imgUrls.map(url => {
+    return imgUrls.map((url, index) => {
       return (
-        <Carousel.Item>
+        <Carousel.Item key={index}>
           <img className="d-block w-100" src={url} alt="Location Image" />
         </Carousel.Item>
       );
@@ -16,7 +16,7 @@ const LocationCarousel = ({ data }) => {
   };
 
   return (
-    <div class="location-carousel">
+    <div className="location-carousel">
       <Carousel>{makeCarouselItem(postImageURLs)}</Carousel>
     </div>
   );

--- a/src/components/LocationCarousel/LocationCarousel.jsx
+++ b/src/components/LocationCarousel/LocationCarousel.jsx
@@ -5,19 +5,17 @@ import Carousel from 'react-bootstrap/Carousel';
 const LocationCarousel = ({ data }) => {
   const { postImageURLs } = data;
 
-  const makeCarouselItem = imgUrls => {
-    return imgUrls.map((url, index) => {
-      return (
-        <Carousel.Item key={index}>
-          <img className="d-block w-100" src={url} alt="Location Image" />
-        </Carousel.Item>
-      );
-    });
-  };
+  const carouselItems = postImageURLs.map((url, index) => {
+    return (
+      <Carousel.Item key={index}>
+        <img className="d-block w-100" src={url} alt="Location Image" />
+      </Carousel.Item>
+    );
+  });
 
   return (
     <div className="location-carousel">
-      <Carousel>{makeCarouselItem(postImageURLs)}</Carousel>
+      <Carousel>{carouselItems}</Carousel>
     </div>
   );
 };

--- a/src/components/LocationCarousel/LocationCarousel.jsx
+++ b/src/components/LocationCarousel/LocationCarousel.jsx
@@ -2,37 +2,22 @@ import React from 'react';
 import './LocationCarousel.scss';
 import Carousel from 'react-bootstrap/Carousel';
 
-const LocationCarousel = () => {
-  // fetch 요청 후 받은 image 의 갯수에 따라 Carousel 컴포넌트 만드는 함수 추가 예정
+const LocationCarousel = ({ data }) => {
+  const { postImageURLs } = data;
+
+  const makeCarouselItem = imgUrls => {
+    return imgUrls.map(url => {
+      return (
+        <Carousel.Item>
+          <img className="d-block w-100" src={url} alt="Location Image" />
+        </Carousel.Item>
+      );
+    });
+  };
 
   return (
     <div class="location-carousel">
-      <Carousel>
-        <Carousel.Item>
-          <img
-            className="d-block w-100"
-            src="https://cdn.pixabay.com/photo/2015/07/10/17/53/cheers-839865_1280.jpg"
-            alt="First slide"
-          />
-          <Carousel.Caption>
-            <h3>First slide label</h3>
-            <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
-          </Carousel.Caption>
-        </Carousel.Item>
-        <Carousel.Item>
-          <img
-            className="d-block w-100"
-            src="https://cdn.pixabay.com/photo/2015/07/10/17/53/cheers-839865_1280.jpg"
-            alt="Secondslide"
-          />
-          <Carousel.Caption>
-            <h3>Second slide label</h3>
-            <p>
-              Praesent commodo cursus magna, vel scelerisque nisl consectetur.
-            </p>
-          </Carousel.Caption>
-        </Carousel.Item>
-      </Carousel>
+      <Carousel>{makeCarouselItem(postImageURLs)}</Carousel>
     </div>
   );
 };

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -6,7 +6,7 @@ import PostItem from '../PostItem/PostItem';
 const PostContainer = ({ items, header }) => {
   const postItems = (items || []).map(item => (
     <Link
-      to={{ pathname: `/post/${item.postId}`, postId: item.postId }}
+      to={`/post/${item.postId}`}
       key={item.postId || Math.floor(Math.random() * 10000)}
     >
       <PostItem headerOn={header} {...item}></PostItem>

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -6,7 +6,7 @@ import PostItem from '../PostItem/PostItem';
 const PostContainer = ({ items, header }) => {
   const postItems = (items || []).map(item => (
     <Link
-      to={`/post/${item.postId}`}
+      to={{ pathname: `/post/${item.postId}`, postId: item.postId }}
       key={item.postId || Math.floor(Math.random() * 10000)}
     >
       <PostItem headerOn={header} {...item}></PostItem>

--- a/src/components/RelatedPost/RelatedPost.jsx
+++ b/src/components/RelatedPost/RelatedPost.jsx
@@ -38,14 +38,14 @@ const RelatedPost = () => {
 
     if (!len) {
       return (
-        <div class="related-post-carousel-wrap">
+        <div className="related-post-carousel-wrap">
           <h3>아직 이 장소를 방문한 다른 사람이 없네요. 🥺</h3>;
         </div>
       );
     } else {
       return (
         <div
-          class="related-post-carousel-wrap"
+          className="related-post-carousel-wrap"
           style={{
             transform: `translateX(${positionX}px)`,
             transition: `transform 1s ease 0s`
@@ -78,21 +78,21 @@ const RelatedPost = () => {
   };
 
   return (
-    <div class="related-post">
+    <div className="related-post">
       <hr></hr>
-      <h2 class="related-post-header">이 장소를 방문한 사람들</h2>
+      <h2 className="related-post-header">이 장소를 방문한 사람들</h2>
 
-      <div class="related-post-carousel">{makeCarouselJsx()}</div>
+      <div className="related-post-carousel">{makeCarouselJsx()}</div>
       {data.length > 5 && (
-        <div class="related-post-carousel-btns">
+        <div className="related-post-carousel-btns">
           <button
-            class="carousel-btns-common prev-btn"
+            className="carousel-btns-common prev-btn"
             onClick={prevBtnHandler}
           >
             &lt;
           </button>
           <button
-            class="carousel-btns-common next-btn"
+            className="carousel-btns-common next-btn"
             onClick={nextBtnHandler}
           >
             &gt;

--- a/src/components/RelatedPost/RelatedPost.jsx
+++ b/src/components/RelatedPost/RelatedPost.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import './RelatedPost.scss';
 import ProfileImage from '../ProfileImage/ProfileImage';
-import RelatedPostComment from '../RelatedPostComment/RelatedPostComment';
+import RelatedPostComment from './RelatedPostComment';
+import { TRANSITION_DURATION_TIME, TRANSITION_DELAY_TIME } from '../../configs';
 
 const RelatedPost = () => {
   const [data, setData] = useState([]);
@@ -36,19 +37,17 @@ const RelatedPost = () => {
   const makeCarouselJsx = () => {
     const len = data.length;
 
-    if (!len) {
-      return (
+    {
+      return !len ? (
         <div className="related-post-carousel-wrap">
           <h3>아직 이 장소를 방문한 다른 사람이 없네요. 🥺</h3>;
         </div>
-      );
-    } else {
-      return (
+      ) : (
         <div
           className="related-post-carousel-wrap"
           style={{
             transform: `translateX(${positionX}px)`,
-            transition: `transform 1s ease 0s`
+            transition: `transform ${TRANSITION_DURATION_TIME} ease ${TRANSITION_DELAY_TIME}`
           }}
         >
           {makeCarouselItem()}

--- a/src/components/RelatedPost/RelatedPostComment.jsx
+++ b/src/components/RelatedPost/RelatedPostComment.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import './RelatedPostComment.scss';
 import ProfileImage from '../ProfileImage/ProfileImage';
 
 const RelatedPostComment = ({ titleCompanion, titleActivity }) => {

--- a/src/components/RelatedPostComment/RelatedPostComment.jsx
+++ b/src/components/RelatedPostComment/RelatedPostComment.jsx
@@ -4,8 +4,8 @@ import ProfileImage from '../ProfileImage/ProfileImage';
 
 const RelatedPostComment = ({ titleCompanion, titleActivity }) => {
   return (
-    <div class="related-post-carousel-item">
-      <h3 class="related-post-comment">
+    <div className="related-post-carousel-item">
+      <h3 className="related-post-comment">
         <ProfileImage medium></ProfileImage>
         {titleCompanion}
         <br />

--- a/src/configs.js
+++ b/src/configs.js
@@ -9,3 +9,6 @@ export const VIEWPORT_HEIGHT = Math.max(
 );
 
 export const MAIN_COLOR = '#fe7c96';
+
+export const TRANSITION_DURATION_TIME = '1s';
+export const TRANSITION_DELAY_TIME = '0s';

--- a/src/pages/DetailPage/DetailPage.jsx
+++ b/src/pages/DetailPage/DetailPage.jsx
@@ -34,7 +34,7 @@ const DetailPage = props => {
         {!loading && (
           <>
             <LocationCarousel></LocationCarousel>
-            <DetailPost />
+            <DetailPost data={data} />
             <MapView data={data} />
             <RelatedPost></RelatedPost>
           </>

--- a/src/pages/DetailPage/DetailPage.jsx
+++ b/src/pages/DetailPage/DetailPage.jsx
@@ -33,7 +33,7 @@ const DetailPage = props => {
         />
         {!loading && (
           <>
-            <LocationCarousel></LocationCarousel>
+            <LocationCarousel data={data}></LocationCarousel>
             <DetailPost data={data} />
             <MapView data={data} />
             <RelatedPost></RelatedPost>

--- a/src/pages/DetailPage/DetailPage.jsx
+++ b/src/pages/DetailPage/DetailPage.jsx
@@ -1,36 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
 import DetailPost from '../../components/DetailPost/DetailPost';
 import LocationCarousel from '../../components/LocationCarousel/LocationCarousel';
 import RelatedPost from '../../components/RelatedPost/RelatedPost';
 import './DetailPage.scss';
 import Header from '../../components/Header/Header';
 import MapView from '../../components/MapView/MapView';
+import useFetch from '../../hooks/useFetch';
+import { WEB_SERVER_URL, MAIN_COLOR } from '../../configs';
+import { css } from '@emotion/core';
+import FadeLoader from 'react-spinners/FadeLoader';
 
-const data = {
-  titlePlace: '공공거실',
-  titleCompanion: '친구랑',
-  titleActivity: '맥주 한잔 하기',
-  description: 'string',
-  postImageUrls: ['string'],
-  locationName: '공공거실',
-  locationAddress: '서울특별시 종로구 창경궁로33길 12',
-  locationPhoneNumber: '000-0000-0000',
-  locationLinkAddress: 'http://www.instagram.com/public_place_',
-  locationLatitude: 37.5843342,
-  locationLongitude: 126.9992411,
-  writerNickname: 'string',
-  writerImageUrl: 'string'
-};
+const DetailPage = props => {
+  console.log(props);
+  const postId = props.location.postId;
+  const [data, setData] = useState({});
 
-const DetailPage = () => {
-  //fetch(url) + if(loading) render(spinner)
+  const { error, loading } = useFetch(
+    `${WEB_SERVER_URL}/post/${postId}`,
+    {},
+    json => setData(json)
+  );
+
   return (
     <div className="detail-page">
       <Header />
       <div className="detail-page-contents">
+        <FadeLoader
+          css={override}
+          sizeUnit={'px'}
+          size={150}
+          color={MAIN_COLOR}
+          loading={loading}
+        />
         <LocationCarousel></LocationCarousel>
         <DetailPost />
-        <MapView data={data} />
+        <MapView data />
         <RelatedPost></RelatedPost>
       </div>
     </div>
@@ -38,3 +42,8 @@ const DetailPage = () => {
 };
 
 export default DetailPage;
+
+const override = css`
+  display: block;
+  margin: 10rem auto;
+`;

--- a/src/pages/DetailPage/DetailPage.jsx
+++ b/src/pages/DetailPage/DetailPage.jsx
@@ -33,10 +33,10 @@ const DetailPage = props => {
         />
         {!loading && (
           <>
-            <LocationCarousel data={data}></LocationCarousel>
+            <LocationCarousel data={data} />
             <DetailPost data={data} />
             <MapView data={data} />
-            <RelatedPost></RelatedPost>
+            <RelatedPost />
           </>
         )}
       </div>

--- a/src/pages/DetailPage/DetailPage.jsx
+++ b/src/pages/DetailPage/DetailPage.jsx
@@ -11,8 +11,7 @@ import { css } from '@emotion/core';
 import FadeLoader from 'react-spinners/FadeLoader';
 
 const DetailPage = props => {
-  console.log(props);
-  const postId = props.location.postId;
+  const postId = props.postId;
   const [data, setData] = useState({});
 
   const { error, loading } = useFetch(
@@ -32,10 +31,14 @@ const DetailPage = props => {
           color={MAIN_COLOR}
           loading={loading}
         />
-        <LocationCarousel></LocationCarousel>
-        <DetailPost />
-        <MapView data />
-        <RelatedPost></RelatedPost>
+        {!loading && (
+          <>
+            <LocationCarousel></LocationCarousel>
+            <DetailPost />
+            <MapView data={data} />
+            <RelatedPost></RelatedPost>
+          </>
+        )}
       </div>
     </div>
   );
@@ -45,5 +48,5 @@ export default DetailPage;
 
 const override = css`
   display: block;
-  margin: 10rem auto;
+  margin: 25rem auto;
 `;

--- a/src/pages/DetailPage/DetailPage.scss
+++ b/src/pages/DetailPage/DetailPage.scss
@@ -15,5 +15,7 @@
     padding: 3rem 2rem;
     background-color: #fff;
     border-radius: 5px;
+    height: 135rem;
+    width: 95rem;
   }
 }


### PR DESCRIPTION
### 구현사항
- MainPage에서 특정 포스트 클릭시 라우터에 postId를 넘겨주고, detail page는 넘겨 받은 postId로 fetch 기능 추가 
  - detail page가 가지고 있는 하위 컴포넌트들 (LocationCarousel, DetailPost, MapView)도 fetch한 데이터에 맞게 렌더링 되도록 리팩토링
- fetch 로딩시 스피너가 화면 중앙에 뜨도록 detail-page-content 의 스타일 변경
- 그 외  eslint 설정 수정으로 key props 없는 것 해결, class -> className으로 클래스 명 수정   

### 참고사항
- RelatedPost fetch 관련 부분도 같은 PR에 넣으려고 했는데, API 수정이 아직 안되 다른 이슈(#33)로 분리했습니다. 백엔드 작업 마무리 되면  추가 PR 보낼게요. 

### 해결된 이슈 번호
- resolved #23 
