### PR TITLE
[15] 로고에 라우터 링크 추가

### DIFF
--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -15,11 +15,8 @@ const Root = () => {
           <Route
             path="/post/:postId"
             render={({ match }) => <DetailPage postId={match.params.postId} />}
-           />
-          <Route
-            path="/profile/edit"
-            render={() => <ProfileEditPage />}
-           />
+          />
+          <Route path="/profile/edit" render={() => <ProfileEditPage />} />
           <Route path="/profile" render={() => <ProfilePage />} />
         </Switch>
       </Router>

--- a/src/components/CommonModal/CommonModal.jsx
+++ b/src/components/CommonModal/CommonModal.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import './CommonModal.scss';
 import OAuthBtn from '../OAuthBtn/OAuthBtn';
-import { IMAGE_BUCKET_URL } from '../../configs';
 import CommonBtn from '../CommonBtn/CommonBtn';
+import { IMAGE_BUCKET_URL, WEB_SERVER_URL } from '../../configs';
 
 const CommonModal = ({ clickHandler, target }) => {
   const content =
@@ -44,6 +44,7 @@ const CommonModal = ({ clickHandler, target }) => {
           <p>{content.desc}</p>
           <div className="common-modal-content-oauth">
             <OAuthBtn
+              href={`${WEB_SERVER_URL}/auth/kakao`}
               company="카카오"
               msg={content.title}
               imgUrl={`${IMAGE_BUCKET_URL}/kakao-logo.png`}

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -34,9 +34,11 @@ const Header = () => {
   return (
     <div className="header-wrapper">
       <div className="header">
-        <Link to="/" className="header-title" onClick={scrollToTop}>
-          <h1>Connect Flavor</h1>
-        </Link>
+        <div className="header-title">
+          <Link to="/" onClick={scrollToTop}>
+            <h1>Connect Flavor</h1>
+          </Link>
+        </div>
         <form onSubmit={handleSubmit}>
           <div className="header-searchbar-icon-wrapper">
             <img
@@ -53,7 +55,7 @@ const Header = () => {
         </form>
         <div className="header-btns">
           {isLoggedIn ? (
-            <Link to={`/profile`}>
+            <Link to="/profile">
               <ProfileImage small />
             </Link>
           ) : (

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -30,7 +30,9 @@ const Header = () => {
   return (
     <div className="header-wrapper">
       <div className="header">
-        <h1>Connect Flavor</h1>
+        <Link to="/" className="header-title">
+          <h1>Connect Flavor</h1>
+        </Link>
         <form onSubmit={handleSubmit}>
           <div className="header-searchbar-icon-wrapper">
             <img

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import './Header.scss';
+import { Link } from 'react-router-dom';
 import useInput from '../../hooks/useInput';
 import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonBtn from '../CommonBtn/CommonBtn';
 import CommonModal from '../CommonModal/CommonModal';
 import { IMAGE_BUCKET_URL } from '../../configs';
 
-const isLoggedIn = false; //TODO: 로그인 기능 구현시 수정
+const isLoggedIn = true; //TODO: 로그인 기능 구현시 수정
 
 const Header = () => {
   const [inputValue, handleChange, restore] = useInput();
@@ -46,7 +47,9 @@ const Header = () => {
         </form>
         <div className="header-btns">
           {isLoggedIn ? (
-            <ProfileImage small />
+            <Link to={`/profile`}>
+              <ProfileImage small />
+            </Link>
           ) : (
             <>
               <CommonBtn

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -27,10 +27,14 @@ const Header = () => {
     clickedSignup ? setClickedSignup(false) : setClickedSignup(true);
   };
 
+  const scrollToTop = () => {
+    window.scrollTo(0, 0);
+  };
+
   return (
     <div className="header-wrapper">
       <div className="header">
-        <Link to="/" className="header-title">
+        <Link to="/" className="header-title" onClick={scrollToTop}>
           <h1>Connect Flavor</h1>
         </Link>
         <form onSubmit={handleSubmit}>

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -19,16 +19,17 @@
   z-index: 1000;
 
   &-title {
+    display: flex;
     flex: 1;
-    &:hover {
+    a:hover {
       text-decoration: none;
     }
     h1 {
-      margin-right: 2rem;
       color: $main-color;
       font-size: 6rem;
       font-weight: bold;
       font-family: 'godoMaum';
+      white-space: nowrap;
       &:hover {
         color: $main-color-light;
       }

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -18,13 +18,21 @@
   border: 1px solid #d4d4d4;
   z-index: 1000;
 
-  h1 {
+  &-title {
     flex: 1;
-    margin-right: 2rem;
-    color: $main-color;
-    font-size: 6rem;
-    font-weight: bold;
-    font-family: 'godoMaum';
+    &:hover {
+      text-decoration: none;
+    }
+    h1 {
+      margin-right: 2rem;
+      color: $main-color;
+      font-size: 6rem;
+      font-weight: bold;
+      font-family: 'godoMaum';
+      &:hover {
+        color: $main-color-light;
+      }
+    }
   }
 
   form {

--- a/src/components/OAuthBtn/OAuthBtn.jsx
+++ b/src/components/OAuthBtn/OAuthBtn.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import './OAuthBtn.scss';
 import CommonBtn from '../CommonBtn/CommonBtn';
 
-const OAuthBtn = ({ company, imgUrl, msg }) => {
+const OAuthBtn = ({ company, imgUrl, msg, href }) => {
   return (
-    <CommonBtn className="OAuth-btn" styleType="none">
-      <img src={imgUrl} />
-      {company} 계정으로 {msg}
-    </CommonBtn>
+    <a href={href} className="OAuth-btn-link">
+      <CommonBtn className="OAuth-btn" styleType="none">
+        <img src={imgUrl} />
+        {company} 계정으로 {msg}
+      </CommonBtn>
+    </a>
   );
 };
 

--- a/src/components/OAuthBtn/OAuthBtn.scss
+++ b/src/components/OAuthBtn/OAuthBtn.scss
@@ -1,7 +1,14 @@
 @import '../../stylesheets/util.scss';
 
+.OAuth-btn-link {
+  display: inline-block;
+  width: 30rem;
+  height: 4.2rem;
+  margin: 1.5rem;
+}
+
 .OAuth-btn {
-  margin-top: 2rem;
+  margin: 0;
   width: 30rem;
 
   span {


### PR DESCRIPTION
### 구현사항
- header의 프로필 이미지 누르면 프로필 페이지로 이동하는 기능 추가
- 로고 누르면 메인 페이지로 이동하는 기능 추가
- 로고에 마우스 hover 시 색상 옅어지도록 스타일 조정
- 로그 누를 때 스크롤이 최상단으로 이동하도록 기능 추가

### 참고사항
- ~~`git checkout feat/15-logo-routing`~~
- `git checkout origin/feat/15-logo-routing`

### 해결된 이슈 번호
- resolved #31 
