### PR TITLE
[20] 프로필 편집버튼 텍스트가 가운데 정렬되지 않는 이슈 해결

### DIFF
--- a/src/components/CommonModal/CommonModal.scss
+++ b/src/components/CommonModal/CommonModal.scss
@@ -29,6 +29,8 @@
 
     h1 {
       font-size: 5rem;
+      font-family: 'godoMaum';
+      color: $main-color;
     }
   }
 

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -24,8 +24,8 @@ const ProfileInfo = ({ data }) => {
           </CommonBtn>
         </div>
         <div className="profile-info-right-column">
-          <div className="profile-info-username">
-            {nickname}
+          <div className="profile-info-header">
+            <span className="profile-info-username">{nickname}</span>
             {isMyProfile && (
               <Link to="/profile/edit">
                 <CommonBtn className="profile-info-edit-btn" styleType="normal">

--- a/src/components/ProfileInfo/ProfileInfo.scss
+++ b/src/components/ProfileInfo/ProfileInfo.scss
@@ -27,10 +27,9 @@
     flex-direction: column;
   }
 
-  &-username {
+  &-header {
     display: flex;
     align-items: center;
-    font-size: 3rem;
     font-weight: bold;
     padding-bottom: 2rem;
 
@@ -43,6 +42,14 @@
     }
   }
 
+  &-username {
+    font-size: 3rem;
+  }
+
+  &-edit-btn {
+    margin: 0;
+  }
+
   &-overview {
     font-size: 2rem;
   }
@@ -50,9 +57,5 @@
   &-introduction {
     font-size: 2rem;
     padding: 1rem 0;
-  }
-
-  &-edit-btn {
-    padding: 0;
   }
 }


### PR DESCRIPTION
### 구현사항
- 프로필 편집버튼 텍스트가 가운데 정렬되지 않는 이슈 해결

### 참고사항
- 프로필 편집버튼과 옆의 유저네임 텍스트를 감싸는 div에 font-size: 3rem 속성이 지정되어 있었어요.
- 해당 속성으로 인해 버튼의 height가 영향을 받았나봐요.
- 유저네임 텍스트를 별도의 span 태그로 감싸고 해당 span에 font-size: 3rem을 주어 해결하였어요.
- <img width="1067" alt="스크린샷 2019-11-08 오후 5 04 36" src="https://user-images.githubusercontent.com/42905468/68459908-eff68480-0249-11ea-99da-d5169c8f9625.png">
- 찾는게 조금 어렵긴 했어요. 첨에는 margin이나 padding 속성을 의심했는데 그건 아니었고,
  그 다음에는 line-height 나 height 같은 속성을 의심했어요. line-height 생각을 하다보니 font-size도 엘리먼트의 크기에 영향을 줄거라는 생각에 요것도 의심했구요.
  의심가는 속성들을 개발자도구에서 하나씩 꺼보면서 상속받는 속성을 따라가면서 찾았어요.
- 어떻게 찾았는지 궁금해 할 것 같아서 대략 끄적끄적 해봤는데 나중에 만나서 설명해주는게 좋겠네요 😊
- 급한건 아니니 리뷰 받고 머지할게요~

### 해결된 이슈 번호
- resolved #47 

---

### 추가사항
- <img width="588" alt="스크린샷 2019-11-08 오후 8 27 13" src="https://user-images.githubusercontent.com/42905468/68473402-3e198100-0266-11ea-9630-1f332115eab9.png">
- `[15] 로고에 라우터 링크 추가` 이슈 해결하면서 회원가입 모달창의 h1 태그 스타일이 영향을 받아서 폰트 스타일이 없어졌어요.
- 해당 이슈도 같이 포함하여 해결하였습니다.