### PR TITLE
[16] RelatedPost의 변경된 API에 따라 fetch 수정

### DIFF
--- a/src/components/DetailPost/DetailPost.scss
+++ b/src/components/DetailPost/DetailPost.scss
@@ -1,9 +1,11 @@
 .detail-post {
   max-width: 700px;
+  margin-bottom: 3rem;
 
   &-title {
     font-size: 4.5rem;
     text-align: center;
+    margin-bottom: 1.5rem;
   }
 
   &-content {
@@ -15,7 +17,12 @@
     margin-right: 2rem;
   }
 
-  &-writer-name,
+  &-writer-name {
+    font-weight: bold;
+    margin-bottom: 1rem;
+    font-size: 2rem;
+  }
+
   &-desc {
     font-size: 2rem;
   }

--- a/src/components/ProfileImage/ProfileImage.scss
+++ b/src/components/ProfileImage/ProfileImage.scss
@@ -1,7 +1,4 @@
 .profile-image {
-  display: flex;
-  justify-content: center;
-  align-items: center;
   border: 1px solid #d4d4d4;
   border-radius: 50%;
 

--- a/src/components/ProfileInfo/ProfileInfo.scss
+++ b/src/components/ProfileInfo/ProfileInfo.scss
@@ -51,8 +51,4 @@
     font-size: 2rem;
     padding: 1rem 0;
   }
-
-  &-edit-btn {
-    padding: 0;
-  }
 }

--- a/src/components/RelatedPost/RelatedPost.jsx
+++ b/src/components/RelatedPost/RelatedPost.jsx
@@ -82,7 +82,8 @@ const RelatedPost = () => {
   const nextBtnHandler = ({ target }) => {
     const maximumIndex = getMaximumIndex();
     if (currentActiveIndex === maximumIndex) return;
-    if (response.hasNextPage && currentActiveIndex % 3 === 0) setPage(page + 1);
+    if (response.hasNextPage && currentActiveIndex === maximumIndex - 1)
+      setPage(page + 1);
     setCurrentActiveIndex(currentActiveIndex + 1);
     setPositionX(positionX - 500);
   };

--- a/src/components/RelatedPost/RelatedPost.jsx
+++ b/src/components/RelatedPost/RelatedPost.jsx
@@ -33,12 +33,13 @@ const RelatedPost = () => {
 
   const makeCarouselItem = () => {
     const items = [...posts];
-    return items.map((item, index) => {
+    return items.map(item => {
       return (
         <RelatedPostComment
           titleCompanion={item.titleCompanion}
           titleActivity={item.titleActivity}
-          key={index}
+          profileImageURL={item.profileImageURL}
+          key={item.postId}
         />
       );
     });
@@ -66,22 +67,21 @@ const RelatedPost = () => {
     }
   };
 
-  const getMaximamIndex = () => {
+  const getMaximumIndex = () => {
     return posts.length % 5 === 0
       ? parseInt(posts.length / 5)
       : parseInt(posts.length / 5) + 1;
   };
 
   const prevBtnHandler = ({ target }) => {
-    const maximamIndex = getMaximamIndex();
     if (currentActiveIndex === 1) return;
     setCurrentActiveIndex(currentActiveIndex - 1);
     setPositionX(positionX + 500);
   };
 
   const nextBtnHandler = ({ target }) => {
-    const maximamIndex = getMaximamIndex();
-    if (currentActiveIndex === maximamIndex) return;
+    const maximumIndex = getMaximumIndex();
+    if (currentActiveIndex === maximumIndex) return;
     if (response.hasNextPage && currentActiveIndex % 3 === 0) setPage(page + 1);
     setCurrentActiveIndex(currentActiveIndex + 1);
     setPositionX(positionX - 500);

--- a/src/components/RelatedPost/RelatedPost.jsx
+++ b/src/components/RelatedPost/RelatedPost.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './RelatedPost.scss';
+import useFetch from '../../hooks/useFetch';
 import ProfileImage from '../ProfileImage/ProfileImage';
 import RelatedPostComment from './RelatedPostComment';
 import {
@@ -12,18 +13,17 @@ const RelatedPost = () => {
   const [data, setData] = useState([]);
   const [currentActiveIndex, setCurrentActiveIndex] = useState(1);
   const [positionX, setPositionX] = useState(0);
+  const [page, setPage] = useState(1);
+  const [hasNextPage, setHasNextPage] = useState(true);
 
-  useEffect(() => {
-    async function fetchData() {
-      const response = await fetch(
-        `${WEB_SERVER_URL}/post/related-to?post-id=1&page=1`
-      );
-      const json = await response.json();
-      setData(json);
+  const { error, loading } = useFetch(
+    `${WEB_SERVER_URL}/post/related-to?postid=1&page=${page}`,
+    {},
+    json => {
+      setData(json.posts);
+      setHasNextPage(json.hasNextPage);
     }
-
-    fetchData();
-  }, []);
+  );
 
   const makeCarouselItem = () => {
     const items = [...data];
@@ -60,22 +60,22 @@ const RelatedPost = () => {
     }
   };
 
-  const getMaximalIndex = () => {
+  const getMaximamIndex = () => {
     return data.length % 5 === 0
       ? parseInt(data.length / 5)
       : parseInt(data.length / 5) + 1;
   };
 
   const prevBtnHandler = ({ target }) => {
-    const maximalIndex = getMaximalIndex();
+    const maximamIndex = getMaximamIndex();
     if (currentActiveIndex === 1) return;
     setCurrentActiveIndex(currentActiveIndex - 1);
     setPositionX(positionX + 500);
   };
 
   const nextBtnHandler = ({ target }) => {
-    const maximalIndex = getMaximalIndex();
-    if (currentActiveIndex === maximalIndex) return;
+    const maximamIndex = getMaximamIndex();
+    if (currentActiveIndex === maximamIndex) return;
     setCurrentActiveIndex(currentActiveIndex + 1);
     setPositionX(positionX - 500);
   };

--- a/src/components/RelatedPost/RelatedPost.scss
+++ b/src/components/RelatedPost/RelatedPost.scss
@@ -5,7 +5,7 @@
   &-header {
     text-align: center;
     font-size: 3.5rem;
-    margin-top: 2rem;
+    margin: 2rem 0;
   }
 
   &-carousel {
@@ -15,7 +15,6 @@
     margin: 0 auto;
 
     h3 {
-      margin: 2rem auto;
       text-align: center;
     }
   }

--- a/src/components/RelatedPost/RelatedPostComment.jsx
+++ b/src/components/RelatedPost/RelatedPostComment.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import ProfileImage from '../ProfileImage/ProfileImage';
+import './RelatedPostComment.scss';
 
-const RelatedPostComment = ({ titleCompanion, titleActivity }) => {
+const RelatedPostComment = ({
+  titleCompanion,
+  titleActivity,
+  profileImageURL
+}) => {
   return (
     <div className="related-post-carousel-item">
+      <ProfileImage medium src={profileImageURL} />
       <h3 className="related-post-comment">
-        <ProfileImage medium />
         {titleCompanion}
         <br />
         {titleActivity}

--- a/src/components/RelatedPost/RelatedPostComment.scss
+++ b/src/components/RelatedPost/RelatedPostComment.scss
@@ -1,4 +1,0 @@
-.related-post-carousel-item {
-  display: flex;
-  flex-direction: column;
-}

--- a/src/components/RelatedPost/RelatedPostComment.scss
+++ b/src/components/RelatedPost/RelatedPostComment.scss
@@ -1,0 +1,4 @@
+.related-post-carousel-item {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/pages/DetailPage/DetailPage.scss
+++ b/src/pages/DetailPage/DetailPage.scss
@@ -14,7 +14,6 @@
     padding: 3rem 2rem;
     background-color: #fff;
     border-radius: 5px;
-    height: 135rem;
     width: 95rem;
   }
 }


### PR DESCRIPTION
### 구현사항
- RelatedPost의 변경된 API에 따라 fetch 수정
  - 사용자가 next-btn 을 클릭했을 때, hasNextPage가 true 이고 3번째 캐러셀 묶음을 보여주고 있다면 미리 fetch해서 데이터가 추가되도록 구현 

### 참고사항
- 메인 페이지에서 무한 스크롤 구현한 것 참고해서 구현했어요. 이전 코드가 잘 짜여 있으니 유사한 기능 추가하기가 쉽네요. :)  
- 포스트 작성자와 설명 부분을 보여주는 영역이 좀 다닥다닥 붙어 있는 것 같아서 margin-bottom을 추가했어요. 

### 해결된 이슈 번호
- resolved #33 
