### PR TITLE
[17] 글 작성 버튼 위에 툴팁 추가

### DIFF
--- a/src/components/NewPostBtn/NewPostBtn.jsx
+++ b/src/components/NewPostBtn/NewPostBtn.jsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import './NewPostBtn.scss';
 import { Link } from 'react-router-dom';
+import ToolTip from './ToolTip.jsx';
 import { NEW_POST_BTN_IMG_URL } from '../../configs';
 
 const NewPostBtn = () => {
-  return <img className="new-post-btn" src={NEW_POST_BTN_IMG_URL} />;
+  return (
+    <>
+      <ToolTip id="new-post-btn">멍멍!(어제 다녀온 곳 올리자!)</ToolTip>
+      <img
+        data-tooltip="new-post-btn"
+        className="new-post-btn"
+        src={NEW_POST_BTN_IMG_URL}
+      />
+    </>
+  );
 };
 
 export default NewPostBtn;

--- a/src/components/NewPostBtn/NewPostBtn.jsx
+++ b/src/components/NewPostBtn/NewPostBtn.jsx
@@ -7,7 +7,9 @@ import { NEW_POST_BTN_IMG_URL } from '../../configs';
 const NewPostBtn = () => {
   return (
     <>
-      <ToolTip id="new-post-btn">멍멍!(어제 다녀온 곳 올리자!)</ToolTip>
+      <ToolTip place="top" id="new-post-btn">
+        멍멍!(어제 다녀온 곳 올리자!)
+      </ToolTip>
       <img
         data-tooltip="new-post-btn"
         className="new-post-btn"

--- a/src/components/NewPostBtn/ToolTip.jsx
+++ b/src/components/NewPostBtn/ToolTip.jsx
@@ -1,12 +1,25 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
-const ToolTip = ({ id, children }) => {
+const ToolTip = ({ width, height, padding, id, children }) => {
+  const [layout, setLayout] = useState(null);
   useEffect(() => {
-    const target = document.querySelector(`[data-tooltip="${id}"]`);
-    console.log(target);
+    const { offsetTop, offsetLeft, clientWidth } = document.querySelector(
+      `[data-tooltip="${id}"]`
+    );
+    setLayout({
+      top: `${offsetTop}px`,
+      left: `${offsetLeft + clientWidth / 2}px`
+    });
   }, []);
   return (
-    <div className="tooltip-background">
+    <div
+      className="tooltip-background"
+      style={{
+        position: 'fixed',
+        ...layout,
+        transform: 'translate(-50%, -200%)'
+      }}
+    >
       <div className="tooltip-arrow" />
       <div className="tooltip-label">{children}</div>
     </div>

--- a/src/components/NewPostBtn/ToolTip.jsx
+++ b/src/components/NewPostBtn/ToolTip.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
+import './ToolTip.scss';
 
 const ToolTip = ({ place, id, children }) => {
   const ref = useRef(null);

--- a/src/components/NewPostBtn/ToolTip.jsx
+++ b/src/components/NewPostBtn/ToolTip.jsx
@@ -1,23 +1,65 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 
-const ToolTip = ({ width, height, padding, id, children }) => {
+const ToolTip = ({ place, id, children }) => {
+  const ref = useRef(null);
   const [layout, setLayout] = useState(null);
+
   useEffect(() => {
-    const { offsetTop, offsetLeft, clientWidth } = document.querySelector(
-      `[data-tooltip="${id}"]`
-    );
-    setLayout({
-      top: `${offsetTop}px`,
-      left: `${offsetLeft + clientWidth / 2}px`
-    });
-  }, []);
+    const { clientHeight, clientWidth } = document.documentElement;
+    const {
+      offsetTop,
+      offsetLeft,
+      offsetWidth,
+      offsetHeight
+    } = document.querySelector(`[data-tooltip="${id}"]`);
+
+    const getLayout = () => {
+      switch (place) {
+        case 'top':
+          return {
+            bottom: `${clientHeight - offsetTop}px`,
+            right: `${clientWidth - (offsetLeft + offsetWidth)}px`,
+            transform: `translate(${-(offsetWidth - ref.current.offsetWidth) /
+              2}px, -100%)`
+          };
+        // TODO: place 값에 따라 레이아웃 바꾸도록 코드 작성
+        // case 'bottom':
+        //   return {
+        //     bottom: `${clientHeight - (offsetTop + offsetHeight)}px`,
+        //     right: `${clientWidth - (offsetLeft + offsetWidth)}px`
+        //   };
+        // case 'left':
+        //   return {
+        //     bottom: `${clientHeight - (offsetTop + offsetHeight)}px`,
+        //     right: `${clientWidth - (offsetLeft + offsetWidth)}px`
+        //   };
+        // case 'right':
+        //   return {
+        //     bottom: `${clientHeight - (offsetTop + offsetHeight)}px`,
+        //     right: `${clientWidth - (offsetLeft + offsetWidth)}px`
+        //   };
+        default:
+          return {
+            bottom: `${clientHeight - offsetTop}px`,
+            right: `${clientWidth - (offsetLeft + offsetWidth)}px`,
+            transform: `translate(${-(offsetWidth - ref.current.offsetWidth) /
+              2}px, -100%)`
+          };
+      }
+    };
+
+    const layout = getLayout();
+
+    setLayout(layout);
+  }, [ref]);
+
   return (
     <div
+      ref={ref}
       className="tooltip-background"
       style={{
         position: 'fixed',
-        ...layout,
-        transform: 'translate(-50%, -200%)'
+        ...layout
       }}
     >
       <div className="tooltip-arrow" />

--- a/src/components/NewPostBtn/ToolTip.jsx
+++ b/src/components/NewPostBtn/ToolTip.jsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+
+const ToolTip = ({ id, children }) => {
+  useEffect(() => {
+    const target = document.querySelector(`[data-tooltip="${id}"]`);
+    console.log(target);
+  }, []);
+  return (
+    <div className="tooltip-background">
+      <div className="tooltip-arrow" />
+      <div className="tooltip-label">{children}</div>
+    </div>
+  );
+};
+
+export default ToolTip;

--- a/src/components/NewPostBtn/ToolTip.scss
+++ b/src/components/NewPostBtn/ToolTip.scss
@@ -1,0 +1,32 @@
+@import '../../stylesheets/util.scss';
+
+$arrow-height: 13px;
+$arrow-width: 10px;
+
+.tooltip {
+  &-background {
+    background-color: #fff;
+    border: 1px solid $main-color;
+    border-radius: 4px;
+  }
+
+  &-arrow {
+    position: absolute;
+    width: 0;
+    height: 0;
+    bottom: calc(-#{$arrow-height} - 1px);
+    left: 50%;
+    margin-left: -$arrow-width;
+    border-width: $arrow-height $arrow-width 0 $arrow-width;
+    border-top-color: $main-color;
+    border-right-color: transparent;
+    border-left-color: transparent;
+    border-style: solid;
+  }
+
+  &-label {
+    padding: 0.25rem 1rem;
+    font-size: 1.5rem;
+    color: #000;
+  }
+}


### PR DESCRIPTION
### 구현사항
- 글 작성 버튼 위에 툴팁 추가
<img width="426" alt="스크린샷 2019-11-10 오후 5 43 43" src="https://user-images.githubusercontent.com/42905468/68541354-af317380-03e1-11ea-943e-2ce7270a41a6.png">


### 참고사항
- 비슷한 기능을 하는 모듈이 많이 있긴한데 hover 시에 나타나거나 클릭 시에 나타나는 게 주된 기능이었어요.
  지금처럼 항상 표시되어야하는 상황에는 사용이 어려워서 직접 구현했어요.
- 약간의 재사용을 고려해서 작성해보았어요.
- 단순히 기존에 있던 버튼 위에 마크업을 추가하지 않고, `data-tooltip`이라는 속성을 통해서 툴팁을 달아줄 타겟 엘리먼트를 찾아서 그 위에 툴팁을 렌더링하도록 작성했어요. 화면 상에 그려진 엘리먼트의 위치를 찾는게 나름 재미있었어요. `offset~~~` 속성이 요긴하게 잘 사용되네요.
- `data-tooltip` 속성을 활용하는 방식은 [요기](https://www.npmjs.com/package/react-tooltip)를 참고했어요.
- 툴팁 css는 [요기](https://medium.com/@jsmuster/building-a-tooltip-component-with-react-2de14761e02) 를 참고했어요.
- place라는 속성을 추가로 주어서 'top, bottom, right, left' 포지션으로 툴팁을 옮길 수 있게 작성하려다가 머리아파서 관두었어요. 필요하면 나중에 추가하는 걸로..

### 해결된 이슈 번호
- resolved #37 
