### PR TITLE
[25] 회원가입 페이지(닉네임입력) 구현

### DIFF
--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -6,6 +6,7 @@ import DetailPage from './pages/DetailPage/DetailPage';
 import ProfileEditPage from './pages/ProfileEditPage/ProfileEditPage';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
 import PostUploadPage from './pages/PostUploadPage/PostUploadPage';
+import SignupPage from './pages/SignupPage/SignupPage';
 
 const Root = () => {
   return (
@@ -20,6 +21,7 @@ const Root = () => {
             path="/post/:postId"
             render={({ match }) => <DetailPage postId={match.params.postId} />}
           />
+          <Route path="/signup" render={() => <SignupPage />} />
         </Switch>
       </Router>
     </>

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -1,9 +1,25 @@
 import React from 'react';
+import './SignupPage.scss';
+import CommonBtn from '../../components/CommonBtn/CommonBtn';
 
 const SignupPage = () => {
   return (
-    <div>
-      <input type="text" placeholder="4~15자로 입력해주세요" />
+    <div className="signup-page">
+      <header>
+        <h1>Connect Flavor</h1>
+      </header>
+      <div className="signup-page-body">
+        <h2>카카오로 회원가입</h2>
+        <div className="signup-page-body-auth-checker">인증완료</div>
+        <span>닉네임을 만들어주세요</span>
+        <div className="signup-page-input-section">
+          <input type="text" placeholder="4~15자로 입력해주세요." />
+          <CommonBtn className="signup-page-duplicate-check-btn">
+            중복검사
+          </CommonBtn>
+        </div>
+        <CommonBtn className="signup-page-signup-btn">회원가입</CommonBtn>
+      </div>
     </div>
   );
 };

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -25,7 +25,7 @@ const SignupPage = () => {
 
   const [reason, setReason] = useState(null);
 
-  const checkNickname = useCallback(async nickname => {
+  const checkNicknameFromServer = useCallback(async nickname => {
     const res = await fetch(`${WEB_SERVER_URL}/validate/nickname`, {
       method: 'POST',
       mode: 'cors',
@@ -60,7 +60,7 @@ const SignupPage = () => {
       //4~15자 영문 소문자, 숫자, 하이픈, 언더바
       //영문으로 시작, 공백 불가
       if (isValid) {
-        checkNickname(nickname);
+        checkNicknameFromServer(nickname);
       } else if (hasBlank) {
         setReason({ valid: false, message: '닉네임에 공백이 있어요.' });
       } else if (nickname.length === 1) {

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -35,16 +35,19 @@ const SignupPage = () => {
     });
     switch (res.status) {
       case 200:
-        setReason('사용 가능한 닉네임이에요.');
+        setReason({ valid: true, message: '사용 가능한 닉네임이에요.' });
         break;
       case 400:
-        setReason('닉네임에 공백이 있어요.');
+        setReason({ valid: false, message: '닉네임에 공백이 있어요.' });
         break;
       case 409:
-        setReason('중복된 닉네임이에요.');
+        setReason({ valid: false, message: '이미 사용중인 닉네임이에요.' });
         break;
       case 500:
-        setReason('서버에서 에러가 발생했어요. 잠시후에 다시 시도해주세요.');
+        setReason({
+          valid: false,
+          message: '서버에서 에러가 발생했어요. 잠시후에 다시 시도해주세요.'
+        });
         break;
       default:
         break;
@@ -60,9 +63,14 @@ const SignupPage = () => {
       if (isValid) {
         checkNickname(nickname);
       } else if (hasBlank) {
-        setReason('닉네임에 공백이 있어요.');
+        setReason({ valid: false, message: '닉네임에 공백이 있어요.' });
+      } else if (nickname.length === 1) {
+        setReason({ valid: false, message: '' });
       } else {
-        setReason('영문으로 시작하는 4~15자의 영문, 숫자 조합을 만들어주세요.');
+        setReason({
+          valid: false,
+          message: '영문으로 시작하는 4~15자의 영문, 숫자 조합을 만들어주세요.'
+        });
       }
     }),
     []
@@ -72,7 +80,7 @@ const SignupPage = () => {
     if (nickname) {
       checkNicknameValidation(nickname);
     } else {
-      setReason('');
+      setReason(null);
     }
   }, [nickname]);
 
@@ -97,7 +105,15 @@ const SignupPage = () => {
             placeholder="4~15자로 입력해주세요."
           />
           <div>
-            <span>{reason}</span>
+            {reason && (
+              <span
+                className={
+                  reason.valid ? 'signup-page-reason-ok' : 'signup-page-reason'
+                }
+              >
+                {reason.message}
+              </span>
+            )}
           </div>
         </div>
         <CommonBtn styleType="normal" className="signup-page-signup-btn">

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -51,18 +51,18 @@ const SignupPage = () => {
     }
   }, []);
 
-  const checkValidNickname = useCallback(
+  const checkNicknameValidation = useCallback(
     debounce(nickname => {
       const hasBlank = /\s/.test(nickname);
       const isValid = /^[a-z][a-z0-9_-]{3,14}$/.test(nickname);
       //4~15자 영문 소문자, 숫자, 하이픈, 언더바
       //영문으로 시작, 공백 불가
-      if (hasBlank) {
-        setReason('닉네임에 공백이 있어요.');
-      } else if (isValid) {
+      if (isValid) {
         checkNickname(nickname);
+      } else if (hasBlank) {
+        setReason('닉네임에 공백이 있어요.');
       } else {
-        setReason('');
+        setReason('영문으로 시작하는 4~15자의 영문, 숫자 조합을 만들어주세요.');
       }
     }),
     []
@@ -70,7 +70,7 @@ const SignupPage = () => {
 
   useEffect(() => {
     if (nickname) {
-      checkValidNickname(nickname);
+      checkNicknameValidation(nickname);
     } else {
       setReason('');
     }

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -3,25 +3,24 @@ import './SignupPage.scss';
 import CommonBtn from '../../components/CommonBtn/CommonBtn';
 import useInput from '../../hooks/useInput';
 import useFetch from '../../hooks/useFetch';
+import { css } from '@emotion/core';
+import FadeLoader from 'react-spinners/FadeLoader';
 import { debounce } from '../../utils/utils';
-import { WEB_SERVER_URL } from '../../configs';
-
-const authData = {
-  provider: '카카오'
-};
+import { WEB_SERVER_URL, MAIN_COLOR } from '../../configs';
 
 const SignupPage = () => {
   const { inputValue, handleChange } = useInput();
   const { nickname } = inputValue;
 
   //임시 토큰 검증
-  // const [authData, setAuthData] = useState(null);
-  // const { loading } = useFetch(
-  //   `${WEB_SERVER_URL}/validate/tempToken`,
-  //   { method: 'POST', credentials: 'include' },
-  //   json => setAuthData(json)
-  // );
-  const { provider } = authData || { provider: '' };
+  const [authData, setAuthData] = useState(null);
+  const { loading } = useFetch(
+    `${WEB_SERVER_URL}/validate/tempToken`,
+    { method: 'POST', credentials: 'include' },
+    json => setAuthData(json)
+  );
+
+  const { provider } = authData || { provider: '(테스트)' }; //TODO: 토큰검증 기능 안정되면 제거
   const postposition = provider === '카카오' ? '로' : '으로';
 
   const [reason, setReason] = useState(null);
@@ -89,39 +88,55 @@ const SignupPage = () => {
       <header>
         <h1>Connect Flavor</h1>
       </header>
-      <div className="signup-page-body">
-        <h2>
-          {provider}
-          {postposition} 회원가입
-        </h2>
-        <div className="signup-page-auth-checker">인증완료</div>
-        <span>닉네임을 만들어주세요</span>
-        <div className="signup-page-input-section">
-          <input
-            name="nickname"
-            value={nickname}
-            onChange={handleChange}
-            type="text"
-            placeholder="4~15자로 입력해주세요."
-          />
-          <div>
-            {reason && (
-              <span
-                className={
-                  reason.valid ? 'signup-page-reason-ok' : 'signup-page-reason'
-                }
-              >
-                {reason.message}
-              </span>
-            )}
+      {!loading && (
+        <div className="signup-page-body">
+          <h2>
+            {provider}
+            {postposition} 회원가입
+          </h2>
+          <div className="signup-page-auth-checker">인증완료</div>
+          <span>닉네임을 만들어주세요</span>
+          <div className="signup-page-input-section">
+            <input
+              name="nickname"
+              value={nickname}
+              onChange={handleChange}
+              type="text"
+              placeholder="4~15자로 입력해주세요."
+            />
+            <div>
+              {reason && (
+                <span
+                  className={
+                    reason.valid
+                      ? 'signup-page-reason-ok'
+                      : 'signup-page-reason'
+                  }
+                >
+                  {reason.message}
+                </span>
+              )}
+            </div>
           </div>
+          <CommonBtn styleType="normal" className="signup-page-signup-btn">
+            회원가입
+          </CommonBtn>
         </div>
-        <CommonBtn styleType="normal" className="signup-page-signup-btn">
-          회원가입
-        </CommonBtn>
-      </div>
+      )}
+      <FadeLoader
+        css={override}
+        sizeUnit={'px'}
+        size={150}
+        color={MAIN_COLOR}
+        loading={loading}
+      />
     </div>
   );
 };
 
 export default SignupPage;
+
+const override = css`
+  display: block;
+  margin: 17rem auto;
+`;

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const SignupPage = () => {
+  return (
+    <div>
+      <input type="text" placeholder="4~15자로 입력해주세요" />
+    </div>
+  );
+};
+
+export default SignupPage;

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -22,7 +22,7 @@ const SignupPage = () => {
   const { provider } = authData || { provider: '(테스트)' }; //TODO: 토큰검증 기능 안정되면 제거
   const postposition = provider === '카카오' ? '로' : '으로';
 
-  const [reason, setReason] = useState(null);
+  const [nicknameValidity, setNicknameValidity] = useState(null);
 
   const checkNicknameFromServer = useCallback(async nickname => {
     const res = await fetch(`${WEB_SERVER_URL}/validate/nickname`, {
@@ -33,16 +33,25 @@ const SignupPage = () => {
     });
     switch (res.status) {
       case 200:
-        setReason({ valid: true, message: '사용 가능한 닉네임이에요.' });
+        setNicknameValidity({
+          valid: true,
+          message: '사용 가능한 닉네임이에요.'
+        });
         break;
       case 400:
-        setReason({ valid: false, message: '닉네임에 공백이 있어요.' });
+        setNicknameValidity({
+          valid: false,
+          message: '닉네임에 공백이 있어요.'
+        });
         break;
       case 409:
-        setReason({ valid: false, message: '이미 사용중인 닉네임이에요.' });
+        setNicknameValidity({
+          valid: false,
+          message: '이미 사용중인 닉네임이에요.'
+        });
         break;
       case 500:
-        setReason({
+        setNicknameValidity({
           valid: false,
           message: '서버에서 에러가 발생했어요. 잠시후에 다시 시도해주세요.'
         });
@@ -54,19 +63,29 @@ const SignupPage = () => {
 
   const checkNicknameValidation = useCallback(
     debounce(nickname => {
-      const hasBlank = /\s/.test(nickname);
       const isValid = /^[a-z][a-z0-9_-]{3,14}$/.test(nickname);
-      if (isValid) {
-        checkNicknameFromServer(nickname);
-      } else if (hasBlank) {
-        setReason({ valid: false, message: '닉네임에 공백이 있어요.' });
-      } else if (nickname.length === 1) {
-        setReason({ valid: false, message: '' });
-      } else {
-        setReason({
-          valid: false,
-          message: '영문으로 시작하는 4~15자의 영문, 숫자 조합을 만들어주세요.'
-        });
+      const hasBlank = /\s/.test(nickname);
+      const onlyOneCharacter = nickname.length === 1;
+      switch (true) {
+        case isValid:
+          checkNicknameFromServer(nickname);
+          break;
+        case hasBlank:
+          setNicknameValidity({
+            valid: false,
+            message: '닉네임에 공백이 있어요.'
+          });
+          break;
+        case onlyOneCharacter:
+          setNicknameValidity({ valid: false, message: '' });
+          break;
+        default:
+          setNicknameValidity({
+            valid: false,
+            message:
+              '영문으로 시작하는 4~15자의 영문, 숫자 조합을 만들어주세요.'
+          });
+          break;
       }
     }),
     []
@@ -76,7 +95,7 @@ const SignupPage = () => {
     if (nickname) {
       checkNicknameValidation(nickname);
     } else {
-      setReason(null);
+      setNicknameValidity(null);
     }
   }, [nickname]);
 
@@ -102,20 +121,20 @@ const SignupPage = () => {
               placeholder="4~15자로 입력해주세요."
             />
             <div>
-              {reason && (
+              {nicknameValidity && (
                 <span
                   className={
-                    reason.valid
+                    nicknameValidity.valid
                       ? 'signup-page-reason-ok'
                       : 'signup-page-reason'
                   }
                 >
-                  {reason.message}
+                  {nicknameValidity.message}
                 </span>
               )}
             </div>
           </div>
-          <CommonBtn styleType="normal" className="signup-page-signup-btn">
+          <CommonBtn styleType="emphasize" className="signup-page-signup-btn">
             회원가입
           </CommonBtn>
         </div>

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -12,7 +12,6 @@ const SignupPage = () => {
   const { inputValue, handleChange } = useInput();
   const { nickname } = inputValue;
 
-  //임시 토큰 검증
   const [authData, setAuthData] = useState(null);
   const { loading } = useFetch(
     `${WEB_SERVER_URL}/validate/tempToken`,
@@ -57,8 +56,6 @@ const SignupPage = () => {
     debounce(nickname => {
       const hasBlank = /\s/.test(nickname);
       const isValid = /^[a-z][a-z0-9_-]{3,14}$/.test(nickname);
-      //4~15자 영문 소문자, 숫자, 하이픈, 언더바
-      //영문으로 시작, 공백 불가
       if (isValid) {
         checkNicknameFromServer(nickname);
       } else if (hasBlank) {

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -1,19 +1,47 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import './SignupPage.scss';
 import CommonBtn from '../../components/CommonBtn/CommonBtn';
+import useInput from '../../hooks/useInput';
+import useFetch from '../../hooks/useFetch';
+import { WEB_SERVER_URL } from '../../configs';
+
+const authData = {
+  organization: '카카오'
+};
 
 const SignupPage = () => {
+  const { inputValue, handleChange } = useInput();
+  const { nickname } = inputValue;
+
+  // const [authData, setAuthData] = useState(null);
+  // const { loading } = useFetch(
+  //   `${WEB_SERVER_URL}/auth/api`,
+  //   { method: 'POST' },
+  //   json => setAuthData(json)
+  // );
+  const { organization } = authData;
+  const postposition = organization === '카카오' ? '로' : '으로';
+
   return (
     <div className="signup-page">
       <header>
         <h1>Connect Flavor</h1>
       </header>
       <div className="signup-page-body">
-        <h2>카카오로 회원가입</h2>
-        <div className="signup-page-body-auth-checker">인증완료</div>
+        <h2>
+          {organization}
+          {postposition} 회원가입
+        </h2>
+        <div className="signup-page-auth-checker">인증완료</div>
         <span>닉네임을 만들어주세요</span>
         <div className="signup-page-input-section">
-          <input type="text" placeholder="4~15자로 입력해주세요." />
+          <input
+            name="nickname"
+            value={nickname}
+            onChange={handleChange}
+            type="text"
+            placeholder="4~15자로 입력해주세요."
+          />
           <CommonBtn className="signup-page-duplicate-check-btn">
             중복검사
           </CommonBtn>

--- a/src/pages/SignupPage/SignupPage.scss
+++ b/src/pages/SignupPage/SignupPage.scss
@@ -46,7 +46,9 @@
   }
 
   &-input-section {
+    position: relative;
     display: flex;
+    align-items: center;
     margin-bottom: 5rem;
 
     > input {
@@ -66,6 +68,13 @@
       &::placeholder {
         color: $gray-font-color;
       }
+    }
+
+    > div {
+      display: flex;
+      position: absolute;
+      right: 1rem;
+      pointer-events: none;
     }
   }
 

--- a/src/pages/SignupPage/SignupPage.scss
+++ b/src/pages/SignupPage/SignupPage.scss
@@ -34,16 +34,15 @@
       font-size: 5rem;
     }
 
-    &-auth-checker {
-      margin-bottom: 4rem;
-      font-size: 2rem;
-      color: violet;
-    }
-
     > span {
       margin-bottom: 3rem;
       font-size: 3rem;
     }
+  }
+  &-auth-checker {
+    margin-bottom: 4rem;
+    font-size: 2rem;
+    color: violet;
   }
 
   &-input-section {

--- a/src/pages/SignupPage/SignupPage.scss
+++ b/src/pages/SignupPage/SignupPage.scss
@@ -1,0 +1,85 @@
+@import '../../stylesheets/util.scss';
+
+.signup-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  header {
+    display: flex;
+    align-items: center;
+    width: 100vw;
+    height: $header-height;
+    padding: 0 5rem;
+    border-bottom: 1px solid $gray-border-color;
+
+    > h1 {
+      color: $main-color;
+      font-size: 6rem;
+      font-weight: bold;
+      font-family: 'godoMaum';
+      white-space: nowrap;
+    }
+  }
+
+  &-body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: calc(100vh - #{$header-height});
+
+    > h2 {
+      margin-bottom: 2rem;
+      font-size: 5rem;
+    }
+
+    &-auth-checker {
+      margin-bottom: 4rem;
+      font-size: 2rem;
+      color: violet;
+    }
+
+    > span {
+      margin-bottom: 3rem;
+      font-size: 3rem;
+    }
+  }
+
+  &-input-section {
+    display: flex;
+    margin-bottom: 5rem;
+
+    > input {
+      width: 37rem;
+      height: 5rem;
+      padding: 0.5rem 1rem;
+      font-size: 2rem;
+      border: 1px solid $gray-border-color;
+      border-radius: 5px;
+
+      &:hover {
+        border: 1px solid #333;
+      }
+      &:focus {
+        outline: none;
+      }
+      &::placeholder {
+        color: $gray-font-color;
+      }
+    }
+  }
+
+  &-duplicate-check-btn {
+    margin: 0;
+    > span {
+      font-size: 2rem;
+    }
+  }
+
+  &-signup-btn {
+    > span {
+      font-size: 2rem;
+    }
+  }
+}

--- a/src/pages/SignupPage/SignupPage.scss
+++ b/src/pages/SignupPage/SignupPage.scss
@@ -78,6 +78,13 @@
     }
   }
 
+  &-reason {
+    color: red;
+    &-ok {
+      color: green;
+    }
+  }
+
   &-duplicate-check-btn {
     margin: 0;
     > span {

--- a/src/pages/SignupPage/SignupPage.scss
+++ b/src/pages/SignupPage/SignupPage.scss
@@ -50,7 +50,7 @@
     margin-bottom: 5rem;
 
     > input {
-      width: 37rem;
+      width: 45rem;
       height: 5rem;
       padding: 0.5rem 1rem;
       font-size: 2rem;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -17,3 +17,11 @@ export const throttle = (callback, delay = 200) => {
     }
   };
 };
+
+export const debounce = (callback, delay = 300) => {
+  let timer;
+  return (...param) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => callback(...param), delay);
+  };
+};


### PR DESCRIPTION
### 구현사항
- 임시토큰 유효성 검사 api요청
  - 응답에 담긴 provider 값으로 어떤 계정으로 로그인하는지 화면렌더링(ex: 카카오, 페북, 인스타)
  - 토큰 유효하지 않은경우 리디렉트 되는 기능은 미구현
- 클라이언트단 닉네임 유효성 검사
  - 영문 소문자로 시작하는 4~15자 영문 소문자, 숫자, 하이픈, 언더바 가능
  - 공백 불가
  - 현재 가능한 케이스 : 1) only 영문소문자, 2) 영문 소문자 + (숫자, 하이픈, 언더바 조합)
  - 디바운스 처리(300ms)
- 닉네임 중복검사 api요청
  - 클라이언트단 유효성 검사를 통과한 경우만 fetch 요청하여 fetch요청 최소화

### 참고사항
- `git checkout feat/origin/25-signup-page`
- 다음 회의 때 닉네임 조합을 어떻게 제한할지 회의해보아요.
- fetch요청을 최소화하기 위해서 클라이언트단 유효성 검사를 넣었는데 지금은 버그가 있어요..
  - 서버 응답이 느려서, '닉네임 가능 여부'를 서버로부터 받기 전에 입력을 다시 시작한 경우,
    *클라이언트단 유효성검사에서 패스하지 못하면*  fetch요청을 취소할 수가 없어서 나중에 온 응답이 화면에 반영 돼요.
    - ex) 1) 유효한 닉네임을 입력한다. 2) fetch 요청을 보낸다. 3) 서버에서 응답 오기전에 입력을 시작한다. 4) 공백포함, 글자수 초과 등 클라이언트 유효성검사에서 fail하는 입력을 한다. 5) fail하는 즉시 안내메시지가 렌더링된다. 6) 이후 서버에서 응답이 오면 사용가능하다고 렌더링된다.
  - 해결방법은 1) 유효성검사를 서버에서만 하도록 하거나, 2) axios나 RxJs 같은 라이브러리를 사용하면 취소가 가능하대요.
  - 라이브러리 사용하는 쪽으로 먼저 살펴볼게요.

### 해결된 이슈 번호
- resolved #56 
