### PR TITLE
[33] 팔로우/언팔로우 기능 구현 및 프로필 페이지의 포스트 목록 api 수정

### DIFF
--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -8,26 +8,31 @@ import ProfilePage from './pages/ProfilePage/ProfilePage';
 import PostUploadPage from './pages/PostUploadPage/PostUploadPage';
 import SignupPage from './pages/SignupPage/SignupPage';
 import LoginContextProvider from './contexts/LoginContext';
+import LoginModalContextProvider from './contexts/LoginModalContext';
 
 const Root = () => {
   return (
     <LoginContextProvider>
-      <Router>
-        <Switch>
-          <Route exact path="/" render={() => <MainPage />} />
-          <Route path="/profile/edit" render={() => <ProfileEditPage />} />
-          <Route path="/profile" render={() => <ProfilePage />} />
-          <Route path="/post/upload" render={() => <PostUploadPage />} />
-          <Route
-            path="/post/:postId"
-            render={({ match }) => <DetailPage postId={match.params.postId} />}
-          />
-          <Route
-            path="/signup"
-            render={({ history }) => <SignupPage history={history} />}
-          />
-        </Switch>
-      </Router>
+      <LoginModalContextProvider>
+        <Router>
+          <Switch>
+            <Route exact path="/" render={() => <MainPage />} />
+            <Route path="/profile/edit" render={() => <ProfileEditPage />} />
+            <Route path="/profile" render={() => <ProfilePage />} />
+            <Route path="/post/upload" render={() => <PostUploadPage />} />
+            <Route
+              path="/post/:postId"
+              render={({ match }) => (
+                <DetailPage postId={match.params.postId} />
+              )}
+            />
+            <Route
+              path="/signup"
+              render={({ history }) => <SignupPage history={history} />}
+            />
+          </Switch>
+        </Router>
+      </LoginModalContextProvider>
     </LoginContextProvider>
   );
 };

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import './Header.scss';
 import useInput from '../../hooks/useInput';
 import ProfileImage from '../ProfileImage/ProfileImage';
@@ -12,20 +12,40 @@ const Header = () => {
   const { inputValue, handleChange, restore } = useInput();
   const [clickedSignup, setClickedSignup] = useState(false);
   const [clickedSignin, setClickedSignin] = useState(false);
-  const { loggedIn, profileImage } = useLoginContext();
+  const {
+    loggedIn,
+    profileImage,
+    needsLoginModal,
+    setNeedsLoginModal
+  } = useLoginContext();
 
   const handleSubmit = e => {
     e.preventDefault();
     restore('searchBar');
   };
 
-  const handleSignin = () => {
-    clickedSignin ? setClickedSignin(false) : setClickedSignin(true);
+  const toggleSigninModal = type => {
+    switch (type) {
+      case 'OPEN':
+        setClickedSignin(true);
+        setNeedsLoginModal(false);
+        break;
+      case 'CLOSE':
+        setClickedSignin(false);
+        break;
+      default:
+        setClickedSignin(!clickedSignin);
+        break;
+    }
   };
 
-  const handleSignup = () => {
-    clickedSignup ? setClickedSignup(false) : setClickedSignup(true);
+  const toggleSignupModal = () => {
+    setClickedSignup(!clickedSignup);
   };
+
+  useMemo(() => {
+    needsLoginModal ? toggleSigninModal('OPEN') : null;
+  }, [needsLoginModal]);
 
   return (
     <div className="header-wrapper">
@@ -58,14 +78,14 @@ const Header = () => {
             <>
               <CommonBtn
                 className="signin-btn"
-                onClick={handleSignin}
+                onClick={toggleSigninModal}
                 styleType="normal"
               >
                 로그인
               </CommonBtn>
               <CommonBtn
                 className="signup-btn"
-                onClick={handleSignup}
+                onClick={toggleSignupModal}
                 styleType="normal"
               >
                 회원가입
@@ -75,11 +95,11 @@ const Header = () => {
         </div>
 
         {!loggedIn && clickedSignin && (
-          <CommonModal clickHandler={handleSignin} target={'signin'} />
+          <CommonModal clickHandler={toggleSigninModal} target={'signin'} />
         )}
 
         {!loggedIn && clickedSignup && (
-          <CommonModal clickHandler={handleSignup} target={'signup'} />
+          <CommonModal clickHandler={toggleSignupModal} target={'signup'} />
         )}
       </div>
     </div>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -6,18 +6,18 @@ import CommonBtn from '../CommonBtn/CommonBtn';
 import CommonModal from '../CommonModal/CommonModal';
 import CommonLink from '../CommonLink/CommonLink';
 import { useLoginContext } from '../../contexts/LoginContext';
+import { useLoginModalContext } from '../../contexts/LoginModalContext';
 import { IMAGE_BUCKET_URL } from '../../configs';
 
 const Header = () => {
   const { inputValue, handleChange, restore } = useInput();
   const [clickedSignup, setClickedSignup] = useState(false);
   const [clickedSignin, setClickedSignin] = useState(false);
+  const { loggedIn, profileImage } = useLoginContext();
   const {
-    loggedIn,
-    profileImage,
-    needsLoginModal,
-    setNeedsLoginModal
-  } = useLoginContext();
+    needsLoginModal: needsSigninModal,
+    setNeedsLoginModal: setNeedsSigninModal
+  } = useLoginModalContext();
 
   const handleSubmit = e => {
     e.preventDefault();
@@ -28,7 +28,7 @@ const Header = () => {
     switch (type) {
       case 'OPEN':
         setClickedSignin(true);
-        setNeedsLoginModal(false);
+        setNeedsSigninModal(false);
         break;
       case 'CLOSE':
         setClickedSignin(false);
@@ -44,8 +44,8 @@ const Header = () => {
   };
 
   useMemo(() => {
-    needsLoginModal ? toggleSigninModal('OPEN') : null;
-  }, [needsLoginModal]);
+    needsSigninModal ? toggleSigninModal('OPEN') : null;
+  }, [needsSigninModal]);
 
   return (
     <div className="header-wrapper">

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -24,7 +24,7 @@ const Header = () => {
     restore('searchBar');
   };
 
-  const toggleSigninModal = type => {
+  const handleSigninModal = type => {
     switch (type) {
       case 'OPEN':
         setClickedSignin(true);
@@ -44,7 +44,7 @@ const Header = () => {
   };
 
   useMemo(() => {
-    needsSigninModal ? toggleSigninModal('OPEN') : null;
+    needsSigninModal ? handleSigninModal('OPEN') : null;
   }, [needsSigninModal]);
 
   return (
@@ -78,7 +78,7 @@ const Header = () => {
             <>
               <CommonBtn
                 className="signin-btn"
-                onClick={toggleSigninModal}
+                onClick={handleSigninModal}
                 styleType="normal"
               >
                 로그인
@@ -95,7 +95,7 @@ const Header = () => {
         </div>
 
         {!loggedIn && clickedSignin && (
-          <CommonModal clickHandler={toggleSigninModal} target={'signin'} />
+          <CommonModal clickHandler={handleSigninModal} target={'signin'} />
         )}
 
         {!loggedIn && clickedSignup && (

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -13,13 +13,13 @@ import {
 } from '../../configs';
 import { throttle } from '../../utils/utils';
 
-const PostContainer = ({ headerOn, api }) => {
+const PostContainer = ({ headerOn, api, query: writerId = '' }) => {
   const [page, setPage] = useState(1);
   const [response, setResponse] = useState(null);
   const items = response ? response.posts : [];
 
   const { error, loading } = useFetch(
-    `${WEB_SERVER_URL}${api}${page}`,
+    `${WEB_SERVER_URL}${api}${page}${writerId ? `&writerId=${writerId}` : ''}`,
     {},
     json => mergeResponse(response, json)
   );

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -19,7 +19,7 @@ const PostContainer = ({ headerOn, api, query: writerId = '' }) => {
   const items = response ? response.posts : [];
 
   const { error, loading } = useFetch(
-    `${WEB_SERVER_URL}${api}${page}${writerId ? `&writerId=${writerId}` : ''}`,
+    `${WEB_SERVER_URL}${api}${page}${writerId ? `&writerid=${writerId}` : ''}`,
     {},
     json => mergeResponse(response, json)
   );

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -3,6 +3,7 @@ import './ProfileInfo.scss';
 import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonBtn from '../CommonBtn/CommonBtn';
 import CommonLink from '../CommonLink/CommonLink';
+import { useLoginContext } from '../../contexts/LoginContext';
 import { WEB_SERVER_URL } from '../../configs';
 
 const ProfileInfo = ({ data, isMyProfile, userId }) => {
@@ -16,7 +17,9 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
     profileImage
   } = data;
   const selfIntro = introduction ? Buffer.from(introduction).toString() : null;
+
   const [isFollowing, setIsFollowing] = useState(initialFollowStatus);
+  const { loggedIn, setNeedsLoginModal } = useLoginContext();
   const [error, setError] = useState(null);
 
   const handleResponse = res => {
@@ -37,6 +40,10 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
   };
 
   const sendRequest = async () => {
+    if (!loggedIn) {
+      setNeedsLoginModal(true);
+      return;
+    }
     const res = await fetch(`${WEB_SERVER_URL}/user/follow/${userId}`, {
       method: `${isFollowing ? 'DELETE' : 'POST'}`,
       credentials: 'include'

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './ProfileInfo.scss';
 import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonBtn from '../CommonBtn/CommonBtn';
 import CommonLink from '../CommonLink/CommonLink';
+import { WEB_SERVER_URL } from '../../configs';
 
-const ProfileInfo = ({ data, isMyProfile }) => {
+const ProfileInfo = ({ data, isMyProfile, userId }) => {
   const {
+    isFollowing: initialFollowStatus,
     nickname,
     totalPost,
     totalFollower,
@@ -14,13 +16,46 @@ const ProfileInfo = ({ data, isMyProfile }) => {
     profileImage
   } = data;
   const selfIntro = introduction ? Buffer.from(introduction).toString() : null;
+  const [isFollowing, setIsFollowing] = useState(initialFollowStatus);
+  const [error, setError] = useState(null);
+
+  const handleResponse = res => {
+    switch (res.status) {
+      case 200:
+        setIsFollowing(true);
+        break;
+      case 400:
+        setError('INVALID_USER_ID');
+        break;
+      case 401:
+        setError('INVALID_TOKEN');
+        break;
+      case 500:
+        setError('SERVER_ERROR');
+        break;
+    }
+  };
+
+  const requestFollow = async () => {
+    const res = await fetch(`${WEB_SERVER_URL}/user/follow/${userId}`, {
+      method: 'POST',
+      credentials: 'include'
+    });
+    handleResponse(res);
+  };
+
   return (
     <div className="profile-info-wrapper">
       <div className="profile-info">
         <div className="profile-info-left-column">
           <ProfileImage large src={profileImage} />
           {!isMyProfile && (
-            <CommonBtn className="profile-info-follow-btn">팔로우</CommonBtn>
+            <CommonBtn
+              className="profile-info-follow-btn"
+              onClick={requestFollow}
+            >
+              {isFollowing ? '팔로우 취소' : '팔로우'}
+            </CommonBtn>
           )}
         </div>
         <div className="profile-info-right-column">

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -4,6 +4,7 @@ import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonBtn from '../CommonBtn/CommonBtn';
 import CommonLink from '../CommonLink/CommonLink';
 import { useLoginContext } from '../../contexts/LoginContext';
+import { useLoginModalContext } from '../../contexts/LoginModalContext';
 import { WEB_SERVER_URL } from '../../configs';
 
 const ProfileInfo = ({ data, isMyProfile, userId }) => {
@@ -19,7 +20,8 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
   const selfIntro = introduction ? Buffer.from(introduction).toString() : null;
 
   const [isFollowing, setIsFollowing] = useState(initialFollowStatus);
-  const { loggedIn, setNeedsLoginModal } = useLoginContext();
+  const { loggedIn } = useLoginContext();
+  const { setNeedsLoginModal } = useLoginModalContext();
   const [error, setError] = useState(null);
 
   const handleResponse = res => {

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -19,10 +19,10 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
   const [isFollowing, setIsFollowing] = useState(initialFollowStatus);
   const [error, setError] = useState(null);
 
-  const handleRequestFollowResponse = res => {
+  const handleResponse = res => {
     switch (res.status) {
       case 200:
-        setIsFollowing(true);
+        setIsFollowing(!isFollowing);
         break;
       case 400:
         setError('INVALID_USER_ID');
@@ -36,37 +36,12 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
     }
   };
 
-  const requestFollow = async () => {
+  const sendRequest = async () => {
     const res = await fetch(`${WEB_SERVER_URL}/user/follow/${userId}`, {
-      method: 'POST',
+      method: `${isFollowing ? 'DELETE' : 'POST'}`,
       credentials: 'include'
     });
-    handleRequestFollowResponse(res);
-  };
-
-  const handleCancelFollowResponse = res => {
-    switch (res.status) {
-      case 200:
-        setIsFollowing(false);
-        break;
-      case 400:
-        setError('INVALID_USER_ID');
-        break;
-      case 401:
-        setError('INVALID_TOKEN');
-        break;
-      case 500:
-        setError('SERVER_ERROR');
-        break;
-    }
-  };
-
-  const cancelFollow = async () => {
-    const res = await fetch(`${WEB_SERVER_URL}/user/follow/${userId}`, {
-      method: 'DELETE',
-      credentials: 'include'
-    });
-    handleCancelFollowResponse(res);
+    handleResponse(res);
   };
 
   return (
@@ -77,7 +52,7 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
           {!isMyProfile && (
             <CommonBtn
               className="profile-info-follow-btn"
-              onClick={isFollowing ? cancelFollow : requestFollow}
+              onClick={sendRequest}
             >
               {isFollowing ? '팔로우 취소' : '팔로우'}
             </CommonBtn>

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -19,7 +19,7 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
   const [isFollowing, setIsFollowing] = useState(initialFollowStatus);
   const [error, setError] = useState(null);
 
-  const handleResponse = res => {
+  const handleRequestFollowResponse = res => {
     switch (res.status) {
       case 200:
         setIsFollowing(true);
@@ -41,7 +41,32 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
       method: 'POST',
       credentials: 'include'
     });
-    handleResponse(res);
+    handleRequestFollowResponse(res);
+  };
+
+  const handleCancelFollowResponse = res => {
+    switch (res.status) {
+      case 200:
+        setIsFollowing(false);
+        break;
+      case 400:
+        setError('INVALID_USER_ID');
+        break;
+      case 401:
+        setError('INVALID_TOKEN');
+        break;
+      case 500:
+        setError('SERVER_ERROR');
+        break;
+    }
+  };
+
+  const cancelFollow = async () => {
+    const res = await fetch(`${WEB_SERVER_URL}/user/follow/${userId}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    });
+    handleCancelFollowResponse(res);
   };
 
   return (
@@ -52,7 +77,7 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
           {!isMyProfile && (
             <CommonBtn
               className="profile-info-follow-btn"
-              onClick={requestFollow}
+              onClick={isFollowing ? cancelFollow : requestFollow}
             >
               {isFollowing ? '팔로우 취소' : '팔로우'}
             </CommonBtn>

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -28,7 +28,7 @@ const ProfileInfo = ({ data, isMyProfile }) => {
             <span className="profile-info-username">{nickname}</span>
             {isMyProfile && (
               <CommonLink to="/profile/edit">
-                <CommonBtn className="profile-info-edit-btn" styleType="normal">
+                <CommonBtn className="profile-info-edit-btn">
                   프로필편집
                 </CommonBtn>
               </CommonLink>

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -13,7 +13,7 @@ const ProfileInfo = ({ data, isMyProfile }) => {
     introduction,
     profileImage
   } = data;
-  const selfIntro = Buffer.from(introduction).toString();
+  const selfIntro = introduction ? Buffer.from(introduction).toString() : null;
   return (
     <div className="profile-info-wrapper">
       <div className="profile-info">

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -4,9 +4,8 @@ import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonBtn from '../CommonBtn/CommonBtn';
 import CommonLink from '../CommonLink/CommonLink';
 
-const ProfileInfo = ({ data }) => {
+const ProfileInfo = ({ data, isMyProfile }) => {
   const {
-    isMyProfile,
     nickname,
     totalPost,
     totalFollower,
@@ -20,9 +19,9 @@ const ProfileInfo = ({ data }) => {
       <div className="profile-info">
         <div className="profile-info-left-column">
           <ProfileImage large src={profileImage} />
-          <CommonBtn className="profile-info-follow-btn" styleType="normal">
-            팔로우
-          </CommonBtn>
+          {!isMyProfile && (
+            <CommonBtn className="profile-info-follow-btn">팔로우</CommonBtn>
+          )}
         </div>
         <div className="profile-info-right-column">
           <div className="profile-info-header">

--- a/src/contexts/LoginContext.jsx
+++ b/src/contexts/LoginContext.jsx
@@ -7,8 +7,6 @@ export const useLoginContext = () => useContext(LoginContext);
 
 const LoginContextProvider = ({ children }) => {
   const [loggedIn, setLoggedIn] = useState(false);
-  const [needsLoginModal, setNeedsLoginModal] = useState(false);
-
   const [userInfo, setUserInfo] = useState({});
   const { id, nickname, profileImage } = userInfo;
 
@@ -29,8 +27,6 @@ const LoginContextProvider = ({ children }) => {
       value={{
         loggedIn,
         setLoggedIn,
-        needsLoginModal,
-        setNeedsLoginModal,
         id,
         nickname,
         profileImage

--- a/src/contexts/LoginContext.jsx
+++ b/src/contexts/LoginContext.jsx
@@ -7,6 +7,8 @@ export const useLoginContext = () => useContext(LoginContext);
 
 const LoginContextProvider = ({ children }) => {
   const [loggedIn, setLoggedIn] = useState(false);
+  const [needsLoginModal, setNeedsLoginModal] = useState(false);
+
   const [userInfo, setUserInfo] = useState({});
   const { id, nickname, profileImage } = userInfo;
 
@@ -24,7 +26,15 @@ const LoginContextProvider = ({ children }) => {
 
   return (
     <LoginContext.Provider
-      value={{ loggedIn, setLoggedIn, id, nickname, profileImage }}
+      value={{
+        loggedIn,
+        setLoggedIn,
+        needsLoginModal,
+        setNeedsLoginModal,
+        id,
+        nickname,
+        profileImage
+      }}
     >
       {children}
     </LoginContext.Provider>

--- a/src/contexts/LoginModalContext.jsx
+++ b/src/contexts/LoginModalContext.jsx
@@ -1,0 +1,16 @@
+import React, { useState, useContext, createContext } from 'react';
+
+const LoginModalContext = createContext();
+
+export const useLoginModalContext = () => useContext(LoginModalContext);
+
+const LoginModalContextProvider = ({ children }) => {
+  const [needsLoginModal, setNeedsLoginModal] = useState(false);
+  return (
+    <LoginModalContext.Provider value={{ needsLoginModal, setNeedsLoginModal }}>
+      {children}
+    </LoginModalContext.Provider>
+  );
+};
+
+export default LoginModalContextProvider;

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -8,15 +8,21 @@ import useFetch from '../../hooks/useFetch';
 import { css } from '@emotion/core';
 import FadeLoader from 'react-spinners/FadeLoader';
 import { WEB_SERVER_URL, MAIN_COLOR } from '../../configs';
+import { useLoginContext } from '../../contexts/LoginContext';
 
-const ProfilePage = props => {
-  //TODO: userId를 넘겨받아서 요청보내도록 수정 예정
-  // const userId = props.userId //match.params에서 넘겨주는 userId
-  const userId = 1;
+const ProfilePage = () => {
+  //TODO: userId를 전역 context에서 받아서 profile-content api 요청하기
+  //라우터URL을 nickname으로 표시하기 때문에 prop으로는 userId를 받을 수 없음.
+  //따라서 userId는 별도의 방법으로 받아야함. 전역 context를 사용해야할 듯.
+  //const { userId } = useContext(someContext);
+  const userId = 103;
+  const { id } = useLoginContext();
+  const isMyProfile = id === userId;
+
   const [data, setData] = useState(null);
   const { error, loading } = useFetch(
     `${WEB_SERVER_URL}/user/profile-content?id=${userId}`,
-    {},
+    { credentials: 'include' },
     setData
   );
   return (
@@ -32,7 +38,7 @@ const ProfilePage = props => {
         color={MAIN_COLOR}
         loading={loading}
       />
-      {data && <ProfileInfo data={data} />}
+      {!loading && <ProfileInfo data={data} isMyProfile={isMyProfile} />}
       <PostContainer api="/post?page=" />
     </div>
   );

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -15,7 +15,7 @@ const ProfilePage = () => {
   //라우터URL을 nickname으로 표시하기 때문에 prop으로는 userId를 받을 수 없음.
   //따라서 userId는 별도의 방법으로 받아야함. 전역 context를 사용해야할 듯.
   //const { userId } = useContext(someContext);
-  const userId = 100;
+  const userId = 103;
   const { id } = useLoginContext();
   const isMyProfile = id === userId;
 

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -19,7 +19,7 @@ const ProfilePage = () => {
   const { id } = useLoginContext();
   const isMyProfile = id === userId;
 
-  const [data, setData] = useState(null);
+  const [data, setData] = useState({});
   const { error, loading } = useFetch(
     `${WEB_SERVER_URL}/user/profile-content?id=${userId}`,
     { credentials: 'include' },

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -38,7 +38,9 @@ const ProfilePage = () => {
         color={MAIN_COLOR}
         loading={loading}
       />
-      {!loading && <ProfileInfo data={data} isMyProfile={isMyProfile} />}
+      {!loading && (
+        <ProfileInfo data={data} isMyProfile={isMyProfile} userId={userId} />
+      )}
       <PostContainer api="/post?page=" query={userId} />
     </div>
   );

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -15,7 +15,7 @@ const ProfilePage = () => {
   //라우터URL을 nickname으로 표시하기 때문에 prop으로는 userId를 받을 수 없음.
   //따라서 userId는 별도의 방법으로 받아야함. 전역 context를 사용해야할 듯.
   //const { userId } = useContext(someContext);
-  const userId = 103;
+  const userId = 100;
   const { id } = useLoginContext();
   const isMyProfile = id === userId;
 
@@ -39,7 +39,7 @@ const ProfilePage = () => {
         loading={loading}
       />
       {!loading && <ProfileInfo data={data} isMyProfile={isMyProfile} />}
-      <PostContainer api="/post?page=" />
+      <PostContainer api="/post?page=" query={userId} />
     </div>
   );
 };


### PR DESCRIPTION
### 구현사항
- **팔로우/언팔로우 기능**
  - 로그인 된 상태일 때, 팔로우/언팔로우 가능하도록 기능 추가
  - 로그인 안 된 상태일 때, 팔로우 버튼을 누르면 로그인 모달창 띄우는 기능 추가
- 프로필 페이지에서 해당 유저의 포스트 목록만 보이도록 api 수정
  - 지금은 백엔드에서 보내주는 응답이 동일해요. 백엔드 코드는 수정 필요
- LoginModalContext작성
  - 로그인모달이 필요한 상태를 관리하는 컨텍스트.
  - LoginContext와는 역할이 다르다고 생각되어 분리했어요.

### 참고사항
- Header컴포넌트에 기존 작성되어 있던 함수를 조금 수정했어요.(`handleSignin() => toggleSigninModal()`)
  수정한 의도는, 함수를 사용하는 쪽에서 *현재 어떤 상황이고, 그래서 어떤 동작을 해야하는지* 명시적으로 알 수 있도록 작성하고자 했습니다.
- profile-content(게시글 수, 팔로워 수 등)를 받아올 때 필요한 userId가 하드코딩 되어있어요.
  다음주에 #71 진행하면서 작업 예정입니다.

### 해결된 이슈 번호
- resolved #69 
