### PR TITLE
[41] 크롬 업데이트에 따른 전체 폰트사이즈 수정

### DIFF
--- a/src/components/CommonModal/CommonModal.scss
+++ b/src/components/CommonModal/CommonModal.scss
@@ -46,7 +46,7 @@
     }
 
     p {
-      font-size: 2rem;
+      font-size: 1.6rem;
       margin-bottom: 2rem;
       color: $gray-font-color;
     }
@@ -57,7 +57,7 @@
     right: 1rem;
     top: 1rem;
     border: none;
-    font-size: 2rem;
+    font-size: 1.6rem;
     font-weight: 200;
   }
 
@@ -65,7 +65,7 @@
     margin: 0;
 
     span {
-      font-size: 2rem;
+      font-size: 1.6rem;
     }
   }
 }

--- a/src/components/DetailPost/DetailPost.scss
+++ b/src/components/DetailPost/DetailPost.scss
@@ -3,7 +3,7 @@
   margin-bottom: 3rem;
 
   &-title {
-    font-size: 4.5rem;
+    font-size: 3.6rem;
     text-align: center;
     margin-bottom: 1.5rem;
   }
@@ -20,11 +20,11 @@
   &-writer-name {
     font-weight: bold;
     margin-bottom: 1rem;
-    font-size: 2rem;
+    font-size: 1.6rem;
   }
 
   &-desc {
-    font-size: 2rem;
+    font-size: 1.6rem;
   }
   .profile-image {
     margin-top: 1.5rem;

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -23,7 +23,7 @@
     flex: 1;
     h1 {
       color: $main-color;
-      font-size: 6rem;
+      font-size: 5rem;
       font-weight: bold;
       font-family: 'godoMaum';
       white-space: nowrap;

--- a/src/components/OAuthBtn/OAuthBtn.scss
+++ b/src/components/OAuthBtn/OAuthBtn.scss
@@ -12,7 +12,7 @@
   width: 30rem;
 
   span {
-    font-size: 1.8rem;
+    font-size: 1.5rem;
   }
 
   img {

--- a/src/components/PostItem/PostItem.scss
+++ b/src/components/PostItem/PostItem.scss
@@ -15,7 +15,7 @@
     align-items: center;
     padding: 1rem 1.5rem;
     span {
-      font-size: 2rem;
+      font-size: 1.6rem;
       font-weight: bold;
       padding-left: 1rem;
     }
@@ -28,7 +28,7 @@
 
   &-title {
     padding: 1rem 1.5rem 0 1.5rem;
-    font-size: 2rem;
+    font-size: 1.6rem;
   }
   &-desc {
     padding: 1rem 1.5rem 2rem 1.5rem;

--- a/src/components/PostUploader/DescriptionUploader.scss
+++ b/src/components/PostUploader/DescriptionUploader.scss
@@ -10,7 +10,7 @@ $color-red: rgb(255, 80, 80);
 
   width: 100%;
   height: 10rem;
-  font-size: 3rem;
+  font-size: 2.4rem;
   border: 1px solid $gray-border-color;
 }
 
@@ -20,7 +20,7 @@ $color-red: rgb(255, 80, 80);
 
 .description-overlimit-message {
   height: 1.5rem;
-  font-size: 1.5rem;
+  font-size: 1.2rem;
   font-weight: bold;
   text-align: right;
   color: $color-red;

--- a/src/components/PostUploader/LocationUploader/LocationFinder.scss
+++ b/src/components/PostUploader/LocationUploader/LocationFinder.scss
@@ -29,7 +29,7 @@
       width: 100%;
       height: 100%;
       border: 0;
-      font-size: 2rem;
+      font-size: 1.6rem;
       &:focus {
         outline: none;
       }

--- a/src/components/PostUploader/LocationUploader/LocationFinderPopupMessage.scss
+++ b/src/components/PostUploader/LocationUploader/LocationFinderPopupMessage.scss
@@ -21,7 +21,7 @@
   &-message {
     color: $main-color;
     font-family: 'godoMaum';
-    font-size: 4rem;
+    font-size: 3.2rem;
     line-height: 4rem;
     white-space: nowrap;
   }

--- a/src/components/PostUploader/LocationUploader/MarkerInfoWindow.scss
+++ b/src/components/PostUploader/LocationUploader/MarkerInfoWindow.scss
@@ -7,5 +7,5 @@
   border-radius: 5px;
   box-shadow: 0 0 10px #777777;
 
-  font-size: 1.75rem;
+  font-size: 1.5rem;
 }

--- a/src/components/PostUploader/LocationUploader/SearchResultLists.scss
+++ b/src/components/PostUploader/LocationUploader/SearchResultLists.scss
@@ -18,7 +18,7 @@ $lists-item-padding: 1rem;
     }
   }
   &-name {
-    font-size: 1.5rem;
+    font-size: 1.2rem;
   }
   &-address {
     color: #888;
@@ -30,7 +30,7 @@ $lists-item-padding: 1rem;
     line-height: calc(#{$lists-item-height} - (#{$lists-item-padding} * 2));
     text-align: center;
     border-bottom: 1px solid $gray-border-color;
-    font-size: 1.5rem;
+    font-size: 1.2rem;
   }
 }
 .search-result {
@@ -42,6 +42,6 @@ $lists-item-padding: 1rem;
   }
 
   &-current-page-number {
-    font-size: 1.5rem;
+    font-size: 1.2rem;
   }
 }

--- a/src/components/PostUploader/PostQuestions.scss
+++ b/src/components/PostUploader/PostQuestions.scss
@@ -14,11 +14,11 @@
   }
 
   div {
-    font-size: 2rem;
+    font-size: 1.6rem;
   }
 
   button {
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     background-color: #fff;
     border: 1px solid $gray-border-color;
     border-radius: 5px;

--- a/src/components/PostUploader/TitleUploader.scss
+++ b/src/components/PostUploader/TitleUploader.scss
@@ -11,7 +11,7 @@
   input {
     width: 20rem;
     height: 5rem;
-    font-size: 4rem;
+    font-size: 3.2rem;
     border: none;
     border-bottom: 1px solid $gray-border-color;
     text-align: center;
@@ -19,7 +19,7 @@
 
   &-location-section {
     > span {
-      font-size: 4rem;
+      font-size: 3.2rem;
       margin-right: 2rem;
     }
   }
@@ -29,7 +29,7 @@
 
     > select {
       width: 20rem;
-      font-size: 4rem;
+      font-size: 3.2rem;
       text-align-last: center;
     }
   }

--- a/src/components/ProfileContentItem/ProfileContentItem.scss
+++ b/src/components/ProfileContentItem/ProfileContentItem.scss
@@ -1,7 +1,7 @@
 @import '../../stylesheets/util.scss';
 
 .profile-edit-page-content-item {
-  font-size: 2rem;
+  font-size: 1.6rem;
   line-height: 3rem;
   margin-top: 2rem;
   display: flex;

--- a/src/components/ProfileInfo/ProfileInfo.scss
+++ b/src/components/ProfileInfo/ProfileInfo.scss
@@ -40,7 +40,7 @@
   }
 
   &-username {
-    font-size: 3rem;
+    font-size: 2.4rem;
   }
 
   &-edit-btn {
@@ -48,11 +48,11 @@
   }
 
   &-overview {
-    font-size: 2rem;
+    font-size: 1.6rem;
   }
 
   &-introduction {
-    font-size: 2rem;
+    font-size: 1.6rem;
     padding: 1rem 0;
   }
 }

--- a/src/components/RelatedPost/RelatedPost.scss
+++ b/src/components/RelatedPost/RelatedPost.scss
@@ -4,7 +4,7 @@
 
   &-header {
     text-align: center;
-    font-size: 3.5rem;
+    font-size: 2.8rem;
     margin: 2rem 0;
   }
 

--- a/src/components/RelatedPost/RelatedPostComment.scss
+++ b/src/components/RelatedPost/RelatedPostComment.scss
@@ -1,0 +1,3 @@
+.related-post-comment {
+  font-size: 1.4rem;
+}

--- a/src/pages/MainPage/MainPage.scss
+++ b/src/pages/MainPage/MainPage.scss
@@ -18,7 +18,7 @@
       right: 5rem;
       padding: 0 5rem;
       color: #fff;
-      font-size: 5rem;
+      font-size: 4rem;
       font-family: 'KCC-eunyoung';
 
       b {

--- a/src/pages/ProfileEditPage/ProfileEditPage.scss
+++ b/src/pages/ProfileEditPage/ProfileEditPage.scss
@@ -25,7 +25,7 @@
     &-item {
       text-align: center;
       padding: 1rem;
-      font-size: 2rem;
+      font-size: 1.6rem;
       border-left: 3px solid $main-color;
       font-weight: bold;
       color: $main-color;
@@ -52,7 +52,7 @@
     bottom: 1rem;
 
     span {
-      font-size: 2rem;
+      font-size: 1.6rem;
     }
   }
 }

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -15,7 +15,7 @@
 }
 
 html {
-  font-size: 8px;
+  font-size: 10px;
 }
 
 body {


### PR DESCRIPTION
### 구현사항
- 크롬 업데이트에 따른 전체 폰트사이즈 수정

### 참고사항
- 업데이트 이전 : width, height, padding 등 font-size를 제외한 곳에 사용되는 1rem의 최소 크기를 10px로 계산
- 업데이트 이후 : 1rem을 코드에 작성한대로 반영(base.scss 에서 8px을 사용하고 있었음)
- width, height 등 레이아웃 크기를 다시 8px에 맞추어 조정하기는 어려우니.. base.scss의 폰트사이즈를 10px로 수정하고, 코드 곳곳의 font-size 속성을 10px기준으로 수정했어요~

### 해결된 이슈 번호
- resolved #81 
