### PR TITLE
[34] Header에 드롭다운 메뉴 추가

### DIFF
--- a/src/components/Header/DropdownMenu.jsx
+++ b/src/components/Header/DropdownMenu.jsx
@@ -10,17 +10,17 @@ const DropdownMenu = ({ onClick }) => {
       <div className="drop-down-menu-wrapper" onClick={onClick} />
       <div className="drop-down-menu">
         <CommonLink to="/post/upload">
-          <div className="drop-down-menu-post-upload-btn">글 작성</div>
+          <div className="drop-down-menu-btns">글 작성</div>
         </CommonLink>
         <CommonLink to={`/profile/@${nickname}`}>
           {/* TODO: NavigationContext로 setUserId(id)필요 */}
-          <div className="drop-down-menu-post-upload-btn">내 프로필</div>
+          <div className="drop-down-menu-btns">내 프로필</div>
         </CommonLink>
         <CommonLink to="/profile/edit">
-          <div className="drop-down-menu-post-upload-btn">프로필 편집</div>
+          <div className="drop-down-menu-btns">프로필 편집</div>
         </CommonLink>
         <CommonLink to="/">
-          <div className="drop-down-menu-post-upload-btn">로그아웃</div>
+          <div className="drop-down-menu-btns">로그아웃</div>
         </CommonLink>
       </div>
     </>

--- a/src/components/Header/DropdownMenu.jsx
+++ b/src/components/Header/DropdownMenu.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import './DropdownMenu.scss';
+
+const DropdownMenu = ({ onClick }) => {
+  return (
+    <>
+      <div className="drop-down-menu-wrapper" onClick={onClick} />
+      <div className="drop-down-menu">dropdown</div>
+    </>
+  );
+};
+
+export default DropdownMenu;

--- a/src/components/Header/DropdownMenu.jsx
+++ b/src/components/Header/DropdownMenu.jsx
@@ -1,14 +1,20 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import './DropdownMenu.scss';
 import CommonLink from '../CommonLink/CommonLink';
 import { useLoginContext } from '../../contexts/LoginContext';
 
 const DropdownMenu = ({ onClick }) => {
   const { nickname } = useLoginContext();
+  const [showsMenu, setShowsMenu] = useState(false);
+
+  useEffect(() => {
+    setShowsMenu(true);
+  }, []);
+
   return (
     <>
       <div className="drop-down-menu-wrapper" onClick={onClick} />
-      <div className="drop-down-menu">
+      <div className={`drop-down-menu ${showsMenu && 'drop-down-menu-show'}`}>
         <CommonLink to="/post/upload">
           <div className="drop-down-menu-btns">글 작성</div>
         </CommonLink>

--- a/src/components/Header/DropdownMenu.jsx
+++ b/src/components/Header/DropdownMenu.jsx
@@ -4,7 +4,7 @@ import CommonLink from '../CommonLink/CommonLink';
 import { useLoginContext } from '../../contexts/LoginContext';
 
 const DropdownMenu = ({ onClick }) => {
-  const { nickname } = useLoginContext();
+  const { nickname, id } = useLoginContext();
   const [showsMenu, setShowsMenu] = useState(false);
 
   useEffect(() => {
@@ -18,8 +18,10 @@ const DropdownMenu = ({ onClick }) => {
         <CommonLink to="/post/upload">
           <div className="drop-down-menu-btns">글 작성</div>
         </CommonLink>
-        <CommonLink to={`/profile/@${nickname}`}>
-          {/* TODO: NavigationContext로 setUserId(id)필요 */}
+        <CommonLink
+          to={`/profile/@${nickname}`}
+          onClick={() => localStorage.setItem('targetUserId', id)}
+        >
           <div className="drop-down-menu-btns">내 프로필</div>
         </CommonLink>
         <CommonLink to="/profile/edit">

--- a/src/components/Header/DropdownMenu.jsx
+++ b/src/components/Header/DropdownMenu.jsx
@@ -1,14 +1,26 @@
 import React from 'react';
 import './DropdownMenu.scss';
 import CommonLink from '../CommonLink/CommonLink';
+import { useLoginContext } from '../../contexts/LoginContext';
 
 const DropdownMenu = ({ onClick }) => {
+  const { nickname } = useLoginContext();
   return (
     <>
       <div className="drop-down-menu-wrapper" onClick={onClick} />
       <div className="drop-down-menu">
         <CommonLink to="/post/upload">
           <div className="drop-down-menu-post-upload-btn">글 작성</div>
+        </CommonLink>
+        <CommonLink to={`/profile/@${nickname}`}>
+          {/* TODO: NavigationContext로 setUserId(id)필요 */}
+          <div className="drop-down-menu-post-upload-btn">내 프로필</div>
+        </CommonLink>
+        <CommonLink to="/profile/edit">
+          <div className="drop-down-menu-post-upload-btn">프로필 편집</div>
+        </CommonLink>
+        <CommonLink to="/">
+          <div className="drop-down-menu-post-upload-btn">로그아웃</div>
         </CommonLink>
       </div>
     </>

--- a/src/components/Header/DropdownMenu.jsx
+++ b/src/components/Header/DropdownMenu.jsx
@@ -3,7 +3,7 @@ import './DropdownMenu.scss';
 import CommonLink from '../CommonLink/CommonLink';
 import { useLoginContext } from '../../contexts/LoginContext';
 
-const DropdownMenu = ({ onClick }) => {
+const DropdownMenu = ({ onClick: toggleDropdownMenu }) => {
   const { nickname, id } = useLoginContext();
   const [showsMenu, setShowsMenu] = useState(false);
 
@@ -13,8 +13,10 @@ const DropdownMenu = ({ onClick }) => {
 
   return (
     <>
-      <div className="drop-down-menu-wrapper" onClick={onClick} />
-      <div className={`drop-down-menu ${showsMenu && 'drop-down-menu-show'}`}>
+      <div className="drop-down-menu-wrapper" onClick={toggleDropdownMenu} />
+      <div
+        className={`drop-down-menu ${showsMenu && 'drop-down-menu-animation'}`}
+      >
         <CommonLink to="/post/upload">
           <div className="drop-down-menu-btns">글 작성</div>
         </CommonLink>

--- a/src/components/Header/DropdownMenu.jsx
+++ b/src/components/Header/DropdownMenu.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import './DropdownMenu.scss';
+import CommonLink from '../CommonLink/CommonLink';
 
 const DropdownMenu = ({ onClick }) => {
   return (
     <>
       <div className="drop-down-menu-wrapper" onClick={onClick} />
-      <div className="drop-down-menu">dropdown</div>
+      <div className="drop-down-menu">
+        <CommonLink to="/post/upload">
+          <div className="drop-down-menu-post-upload-btn">글 작성</div>
+        </CommonLink>
+      </div>
     </>
   );
 };

--- a/src/components/Header/DropdownMenu.scss
+++ b/src/components/Header/DropdownMenu.scss
@@ -25,7 +25,7 @@ $drop-down-btn-height: 3rem;
   transition: height 0.2s;
   opacity: 0;
 
-  &-show {
+  &-animation {
     height: calc(#{$drop-down-btn-height}* 4);
     opacity: 1;
   }

--- a/src/components/Header/DropdownMenu.scss
+++ b/src/components/Header/DropdownMenu.scss
@@ -16,15 +16,22 @@ $drop-down-btn-height: 3rem;
   top: calc(#{$header-height} - 0.5rem);
   right: 0;
   width: 10rem;
-  height: 10rem;
+  border: 1px solid $main-color;
+  border-radius: 5px;
+  box-shadow: 0 0 10px #333;
   background-color: #fff;
-  outline: 1px solid black;
 
-  &-post-upload-btn {
+  &-btns {
     width: 100%;
     height: $drop-down-btn-height;
-    border: 1px solid black;
-    text-align: center;
+    font-size: 1.2rem;
     line-height: $drop-down-btn-height;
+    border-bottom: 1px solid $main-color;
+    text-align: center;
+    cursor: pointer;
+
+    &:hover {
+      background-color: $point-color;
+    }
   }
 }

--- a/src/components/Header/DropdownMenu.scss
+++ b/src/components/Header/DropdownMenu.scss
@@ -16,10 +16,19 @@ $drop-down-btn-height: 3rem;
   top: calc(#{$header-height} - 0.5rem);
   right: 0;
   width: 10rem;
+  height: 0;
   border: 1px solid $main-color;
   border-radius: 5px;
   box-shadow: 0 0 10px #333;
   background-color: #fff;
+  overflow: hidden;
+  transition: height 0.2s;
+  opacity: 0;
+
+  &-show {
+    height: calc(#{$drop-down-btn-height}* 4);
+    opacity: 1;
+  }
 
   &-btns {
     width: 100%;

--- a/src/components/Header/DropdownMenu.scss
+++ b/src/components/Header/DropdownMenu.scss
@@ -17,4 +17,12 @@
   height: 10rem;
   background-color: #fff;
   outline: 1px solid black;
+
+  &-post-upload-btn {
+    width: 100%;
+    height: 4rem;
+    border: 1px solid black;
+    text-align: center;
+    line-height: 4rem;
+  }
 }

--- a/src/components/Header/DropdownMenu.scss
+++ b/src/components/Header/DropdownMenu.scss
@@ -1,6 +1,7 @@
 @import '../../stylesheets/util.scss';
 
 $drop-down-btn-height: 3rem;
+$btn-quantity: 4;
 
 .drop-down-menu {
   &-wrapper {
@@ -26,7 +27,7 @@ $drop-down-btn-height: 3rem;
   opacity: 0;
 
   &-animation {
-    height: calc(#{$drop-down-btn-height}* 4);
+    height: calc(#{$drop-down-btn-height} * #{$btn-quantity});
     opacity: 1;
   }
 

--- a/src/components/Header/DropdownMenu.scss
+++ b/src/components/Header/DropdownMenu.scss
@@ -1,0 +1,20 @@
+@import '../../stylesheets/util.scss';
+
+.drop-down-menu {
+  &-wrapper {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    opacity: 0;
+  }
+
+  position: absolute;
+  top: calc(#{$header-height} - 0.5rem);
+  right: 0;
+  width: 10rem;
+  height: 10rem;
+  background-color: #fff;
+  outline: 1px solid black;
+}

--- a/src/components/Header/DropdownMenu.scss
+++ b/src/components/Header/DropdownMenu.scss
@@ -1,5 +1,7 @@
 @import '../../stylesheets/util.scss';
 
+$drop-down-btn-height: 3rem;
+
 .drop-down-menu {
   &-wrapper {
     position: fixed;
@@ -20,9 +22,9 @@
 
   &-post-upload-btn {
     width: 100%;
-    height: 4rem;
+    height: $drop-down-btn-height;
     border: 1px solid black;
     text-align: center;
-    line-height: 4rem;
+    line-height: $drop-down-btn-height;
   }
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -5,6 +5,7 @@ import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonBtn from '../CommonBtn/CommonBtn';
 import CommonModal from '../CommonModal/CommonModal';
 import CommonLink from '../CommonLink/CommonLink';
+import DropdownMenu from './DropdownMenu';
 import { useLoginContext } from '../../contexts/LoginContext';
 import { useLoginModalContext } from '../../contexts/LoginModalContext';
 import { IMAGE_BUCKET_URL } from '../../configs';
@@ -13,7 +14,8 @@ const Header = () => {
   const { inputValue, handleChange, restore } = useInput();
   const [clickedSignup, setClickedSignup] = useState(false);
   const [clickedSignin, setClickedSignin] = useState(false);
-  const { loggedIn, profileImage, nickname, id } = useLoginContext();
+  const [showsDropdown, setShowsDropdown] = useState(false);
+  const { loggedIn, profileImage } = useLoginContext();
   const {
     needsLoginModal: needsSigninModal,
     setNeedsLoginModal: setNeedsSigninModal
@@ -41,6 +43,10 @@ const Header = () => {
 
   const toggleSignupModal = () => {
     setClickedSignup(!clickedSignup);
+  };
+
+  const toggleDropdownMenu = () => {
+    setShowsDropdown(prevState => !prevState);
   };
 
   useMemo(() => {
@@ -71,12 +77,16 @@ const Header = () => {
         </form>
         <div className="header-btns">
           {loggedIn ? (
-            <CommonLink
-              to={`/profile/@${nickname}`}
-              onClick={() => localStorage.setItem('targetUserId', id)}
-            >
-              <ProfileImage small src={profileImage} />
-            </CommonLink>
+            <>
+              <ProfileImage
+                small
+                src={profileImage}
+                className={`header-profile-img ${showsDropdown &&
+                  'over-dropdown-background'}`}
+                onClick={toggleDropdownMenu}
+              />
+              {showsDropdown && <DropdownMenu onClick={toggleDropdownMenu} />}
+            </>
           ) : (
             <>
               <CommonBtn

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -46,7 +46,7 @@ const Header = () => {
   };
 
   const toggleDropdownMenu = () => {
-    setShowsDropdown(prevState => !prevState);
+    setShowsDropdown(state => !state);
   };
 
   useMemo(() => {

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -63,6 +63,16 @@
     font-size: 1.75rem;
   }
 
+  &-profile-img {
+    &:hover {
+      box-shadow: 0 0 5px $main-color;
+    }
+  }
+
+  .over-dropdown-background {
+    z-index: 1000;
+  }
+
   &-btns {
     flex: 1;
     display: flex;

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import './ProfileInfo.scss';
 import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonBtn from '../CommonBtn/CommonBtn';
-import CommonLink from '../CommonLink/CommonLink';
 import { useLoginContext } from '../../contexts/LoginContext';
 import { useLoginModalContext } from '../../contexts/LoginModalContext';
 import { WEB_SERVER_URL } from '../../configs';
@@ -69,13 +68,6 @@ const ProfileInfo = ({ data, isMyProfile, userId }) => {
         <div className="profile-info-right-column">
           <div className="profile-info-header">
             <span className="profile-info-username">{nickname}</span>
-            {isMyProfile && (
-              <CommonLink to="/profile/edit">
-                <CommonBtn className="profile-info-edit-btn">
-                  프로필편집
-                </CommonBtn>
-              </CommonLink>
-            )}
           </div>
           <div className="profile-info-overview">게시글 {totalPosts}개</div>
           <div className="profile-info-overview">팔로워 {totalFollowers}명</div>


### PR DESCRIPTION
### 구현사항
![dropdownmenu](https://user-images.githubusercontent.com/42905468/71426729-66175380-26f1-11ea-8298-2e9085b2af02.gif)

- 로그인한 상태에서 헤더의 프로필 이미지를 클릭시 드롭다운메뉴 열리는 기능 구현
- 드롭다운 메뉴에 1) 글 작성, 2) 내 프로필, 3) 프로필 편집, 4) 로그아웃 버튼 추가
- 드롭다운 메뉴는 스르륵 열리도록 애니메이션 구현(스르륵 닫히는건 미구현)

### 참고사항
- '내 프로필'로 이동하는 기능은 현재 open 중인 PR #84 의 기능이 필요해요.  
 이 기능은 코드가 매우 간단하기 때문에 해당 PR merge 되면 이 브랜치를 rebase해서 추가 커밋할 생각이에요.
- 로그아웃 기능은 아직 미구현입니다. 별도 이슈로 분리하여 개발예정이에요.(#74 )

### 해결된 이슈 번호
- resolved #70 
