### PR TITLE
[46] 무한스크롤 버그, 관련 포스트 목록 버그 등 수정

### DIFF
--- a/src/components/DetailPost/DetailPost.jsx
+++ b/src/components/DetailPost/DetailPost.jsx
@@ -15,7 +15,7 @@ const DetailPost = ({
   return (
     <div className="detail-post">
       <h1 className="detail-post-title">
-        {place}에서 {companion}랑 {activity}
+        {place}에서 {companion} {activity}
       </h1>
       <div className="detail-post-content">
         <CommonLink

--- a/src/components/PostContainer/PostContainer.jsx
+++ b/src/components/PostContainer/PostContainer.jsx
@@ -54,7 +54,7 @@ const PostContainer = ({ headerOn, writerId = '' }) => {
   });
 
   const hasNextPage = response => {
-    return response && !response.hasNextPage;
+    return response && response.hasNextPage;
   };
 
   const isScrollEnd = () => {

--- a/src/components/PostUploader/TitleUploader.scss
+++ b/src/components/PostUploader/TitleUploader.scss
@@ -17,6 +17,12 @@
     text-align: center;
   }
 
+  &-place-section {
+    > span {
+      font-size: 3.2rem;
+    }
+  }
+
   &-location-section {
     > span {
       font-size: 3.2rem;

--- a/src/components/RelatedPost/RelatedPost.jsx
+++ b/src/components/RelatedPost/RelatedPost.jsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import './RelatedPost.scss';
 import useFetch from '../../hooks/useFetch';
-import ProfileImage from '../ProfileImage/ProfileImage';
 import RelatedPostComment from './RelatedPostComment';
 import {
   TRANSITION_DURATION_TIME,
@@ -9,7 +8,7 @@ import {
   WEB_SERVER_URL
 } from '../../configs';
 
-const RelatedPost = () => {
+const RelatedPost = ({ postId }) => {
   const [currentActiveIndex, setCurrentActiveIndex] = useState(1);
   const [positionX, setPositionX] = useState(0);
   const [page, setPage] = useState(1);
@@ -20,7 +19,7 @@ const RelatedPost = () => {
     error,
     loading
   } = useFetch(
-    `${WEB_SERVER_URL}/post/related-to?postid=1&page=${page}`,
+    `${WEB_SERVER_URL}/post/related-to?postid=${postId}&page=${page}`,
     {},
     json => mergeResponse(response, json)
   );

--- a/src/pages/DetailPage/DetailPage.jsx
+++ b/src/pages/DetailPage/DetailPage.jsx
@@ -36,7 +36,7 @@ const DetailPage = props => {
             <LocationCarousel data={data} />
             <DetailPost data={data} />
             <MapView data={data} />
-            <RelatedPost />
+            <RelatedPost postId={postId} />
           </>
         )}
       </div>


### PR DESCRIPTION
### 구현사항
- 무한스크롤 작동하지 않는 버그 수정
- DetailPage의 ‘누구랑‘부분 마크업에서 ‘랑’을 삭제
- PostUploadPage의 장소‘에서’ 폰트 사이즈 수정
- RelatedPost 컴포넌트가 postId를 기반으로 동작하도록 수정

### 해결된 이슈 번호
- resolved #94 
