### PR TITLE
[54] 반응형 웹 적용, TitleUploader UX 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "npm:@hot-loader/react-dom",
     "react-hot-loader": "^4.12.14",
     "react-kakao-maps": "^0.0.11",
+    "react-responsive": "^8.0.3",
     "react-router-dom": "^5.1.0",
     "react-spinners": "^0.6.1",
     "styled-components": "^4.4.1"

--- a/src/components/CommonModal/CommonModal.jsx
+++ b/src/components/CommonModal/CommonModal.jsx
@@ -3,11 +3,13 @@ import classNames from 'classnames/bind';
 import styles from './CommonModal.scss';
 import OAuthBtn from '../OAuthBtn/OAuthBtn';
 import CommonBtn from '../CommonBtn/CommonBtn';
+import useModal from '../../hooks/useModal';
 import { IMAGE_BUCKET_URL, WEB_SERVER_URL } from '../../configs';
 
 const cx = classNames.bind(styles);
 
 const CommonModal = ({ onClose, target }) => {
+  const { Modal } = useModal();
   const content =
     target === `signin`
       ? {
@@ -27,53 +29,43 @@ const CommonModal = ({ onClose, target }) => {
           hyperlinkMsg: '로그인하기'
         };
 
-  useEffect(() => {
-    document.body.style.overflow = 'hidden';
-    return () => (document.body.style.overflow = 'unset');
-  }, []);
-
   return (
-    <>
-      <div className={cx('overlay')} />
+    <Modal onClick={onClose}>
       <div className={cx('wrapper')}>
         <button className={cx('close-btn')} onClick={onClose}>
           닫기
         </button>
-        <div className={cx('content')}>
-          <div className={cx('header')}>
-            <img src={`${IMAGE_BUCKET_URL}/logo.png`} />
-            <h1>서비스 {content.title}</h1>
-          </div>
-          <p>{content.desc}</p>
-          <div className={cx('content-oauth')}>
-            <OAuthBtn
-              href={`${WEB_SERVER_URL}/auth/kakao`}
-              company="카카오"
-              msg={content.title}
-              imgUrl={`${IMAGE_BUCKET_URL}/kakao-logo.png`}
-            />
-            <OAuthBtn
-              company="페이스북"
-              msg={content.title}
-              imgUrl={`${IMAGE_BUCKET_URL}/facebook-logo.png`}
-            />
-            <OAuthBtn
-              company="인스타그램"
-              msg={content.title}
-              imgUrl={`${IMAGE_BUCKET_URL}/insta-logo.png`}
-            />
-          </div>
-          <p>
-            {content.reminderMsg}
-            <CommonBtn className={cx('reminder-btn')} styleType="underline">
-              <a href={`${WEB_SERVER_URL}/auth/kakao`}>
-                {content.hyperlinkMsg}
-              </a>
-            </CommonBtn>
-          </p>
+        <div className={cx('header')}>
+          <img src={`${IMAGE_BUCKET_URL}/logo.png`} />
+          <h1>서비스 {content.title}</h1>
         </div>
+        <p>{content.desc}</p>
+        <div className={cx('oauth')}>
+          <OAuthBtn
+            href={`${WEB_SERVER_URL}/auth/kakao`}
+            company="카카오"
+            msg={content.title}
+            imgUrl={`${IMAGE_BUCKET_URL}/kakao-logo.png`}
+          />
+          <OAuthBtn
+            company="페이스북"
+            msg={content.title}
+            imgUrl={`${IMAGE_BUCKET_URL}/facebook-logo.png`}
+          />
+          <OAuthBtn
+            company="인스타그램"
+            msg={content.title}
+            imgUrl={`${IMAGE_BUCKET_URL}/insta-logo.png`}
+          />
+        </div>
+        <p>
+          {content.reminderMsg}
+          <CommonBtn className={cx('reminder-btn')} styleType="underline">
+            <a href={`${WEB_SERVER_URL}/auth/kakao`}>{content.hyperlinkMsg}</a>
+          </CommonBtn>
+        </p>
       </div>
-    </>
+    </Modal>
   );
 };
 

--- a/src/components/CommonModal/CommonModal.scss
+++ b/src/components/CommonModal/CommonModal.scss
@@ -1,22 +1,12 @@
 @import '../../stylesheets/util.scss';
 
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  background-color: rgba(0, 0, 0, 0.16);
-}
-
 .wrapper {
-  position: fixed;
-  left: 30%;
-  top: 20%;
-  width: 60rem;
+  position: relative;
+  width: 95vw;
+  padding: 1rem 2rem;
   background-color: white;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
-  z-index: 999;
+  text-align: center;
 
   .header {
     height: 14rem;
@@ -34,45 +24,48 @@
     }
   }
 
-  .content {
-    width: 50rem;
-    margin: 0 auto;
-    margin-top: 3rem;
-    text-align: center;
-
-    &-oauth {
-      width: 70%;
-      margin: 2rem auto;
-    }
-
-    p {
-      font-size: 1.6rem;
-      margin-bottom: 2rem;
-      color: $gray-font-color;
-    }
+  .oauth {
+    max-width: 40rem;
+    margin: 2rem auto;
   }
 
-  .close-btn {
-    position: absolute;
-    right: 1rem;
-    top: 1rem;
-    border: none;
+  p {
+    margin-bottom: 2rem;
     font-size: 1.6rem;
-    font-weight: 200;
+    color: $gray-font-color;
+  }
+}
+
+.close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  font-size: 1.6rem;
+  font-weight: 200;
+  background-color: #fff;
+}
+
+.reminder-btn {
+  margin: 0;
+  background-color: #fff;
+
+  span {
+    font-size: 1.6rem;
   }
 
-  .reminder-btn {
-    margin: 0;
-
-    span {
-      font-size: 1.6rem;
+  a {
+    color: $main-color;
+    &:hover {
+      color: $main-color-light;
     }
-
-    a {
-      color: $main-color;
-      &:hover {
-        color: $main-color-light;
-      }
+  }
+}
+@include tablet-and-desktop {
+  .wrapper {
+    max-width: 65rem;
+    p {
+      white-space: nowrap;
     }
   }
 }

--- a/src/components/CommonPost/CommonPost.scss
+++ b/src/components/CommonPost/CommonPost.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 100vw;
   min-height: calc(100vh - #{$header-height});
-  padding: 5rem;
+  padding: 5rem 0;
   background-color: $gray-background-color;
 }
 
@@ -25,6 +25,18 @@
 }
 
 .large {
-  width: 80rem;
+  width: 100%;
   min-height: 60rem;
+}
+
+@include tablet {
+  .large {
+    max-width: 70rem;
+  }
+}
+
+@include desktop {
+  .large {
+    max-width: 80rem;
+  }
 }

--- a/src/components/DetailPost/DetailPost.jsx
+++ b/src/components/DetailPost/DetailPost.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames/bind';
 import styles from './DetailPost.scss';
 import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonLink from '../CommonLink/CommonLink';
+import useMediaQuerySet from '../../hooks/useMediaQuerySet';
 
 const cx = classNames.bind(styles);
 
@@ -12,10 +13,11 @@ const DetailPost = ({
     writer: { id, nickname, profileImage } = {}
   }
 }) => {
+  const { isMobile } = useMediaQuerySet();
   return (
     <div className={cx('wrapper')}>
       <h1 className={cx('title')}>
-        {place}에서 {companion} {activity}
+        {place}에서{isMobile && <br />} {companion} {activity}
       </h1>
       <div className={cx('content')}>
         <CommonLink

--- a/src/components/DetailPost/DetailPost.scss
+++ b/src/components/DetailPost/DetailPost.scss
@@ -1,32 +1,45 @@
+@import '../../stylesheets/util.scss';
+
 .wrapper {
-  max-width: 700px;
+  width: 100%;
   margin-bottom: 3rem;
+}
+.title {
+  font-size: $medium-title-font-size;
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
 
+.content {
+  display: flex;
+  margin: 0 1rem;
+}
+
+.writer-img {
+  margin-right: 2rem;
+}
+
+.writer-name {
+  font-weight: bold;
+  margin-bottom: 1rem;
+  font-size: 1.6rem;
+}
+
+.desc {
+  font-size: 1.6rem;
+}
+.profile-image {
+  margin-top: 1.5rem;
+}
+
+@include tablet-and-desktop {
+  .wrapper {
+    max-width: 700px;
+  }
   .title {
-    font-size: 3.6rem;
-    text-align: center;
-    margin-bottom: 1.5rem;
+    font-size: $large-title-font-size;
   }
-
   .content {
-    display: flex;
     margin: 0 3rem;
-  }
-
-  .writer-img {
-    margin-right: 2rem;
-  }
-
-  .writer-name {
-    font-weight: bold;
-    margin-bottom: 1rem;
-    font-size: 1.6rem;
-  }
-
-  .desc {
-    font-size: 1.6rem;
-  }
-  .profile-image {
-    margin-top: 1.5rem;
   }
 }

--- a/src/components/DetailPostHeader/DetailPostHeader.scss
+++ b/src/components/DetailPostHeader/DetailPostHeader.scss
@@ -13,4 +13,5 @@
 .btns {
   margin: 0.6rem 1rem;
   padding: 0;
+  background-color: #fff;
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames/bind';
 import styles from './Header.scss';
 import useInput from '../../hooks/useInput';
@@ -7,12 +7,14 @@ import CommonBtn from '../CommonBtn/CommonBtn';
 import CommonModal from '../CommonModal/CommonModal';
 import CommonLink from '../CommonLink/CommonLink';
 import DropdownMenu from './DropdownMenu';
+import useMediaQuerySet from '../../hooks/useMediaQuerySet';
 import { useLoginContext } from '../../contexts/LoginContext';
 import { IMAGE_BUCKET_URL } from '../../configs';
 
 const cx = classNames.bind(styles);
 
 const Header = () => {
+  const { isMobile } = useMediaQuerySet();
   const { inputValue, handleChange, restore } = useInput();
   const [showsDropdown, setShowsDropdown] = useState(false);
   const {
@@ -39,23 +41,35 @@ const Header = () => {
       <div className={cx('header')}>
         <div className={cx('title')}>
           <CommonLink to="/">
-            <h1>Connect Flavor</h1>
+            {isMobile ? (
+              <img src={`${IMAGE_BUCKET_URL}/logo.png`} />
+            ) : (
+              <h1>Connect Flavor</h1>
+            )}
           </CommonLink>
         </div>
-        <form onSubmit={handleSubmit}>
-          <div className={cx('searchbar-icon-wrapper')}>
-            <img
-              className={cx('searchbar-icon')}
-              src={`${IMAGE_BUCKET_URL}/magnifier-icon.png`}
-              alt=""
-            />
-          </div>
-          <input
-            name="searchBar"
-            value={inputValue.searchBar}
-            onChange={handleChange}
+        {isMobile ? (
+          <img
+            className={cx('searchbar-icon')}
+            src={`${IMAGE_BUCKET_URL}/magnifier-icon.png`}
+            alt=""
           />
-        </form>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div className={cx('searchbar-icon-wrapper')}>
+              <img
+                className={cx('searchbar-icon')}
+                src={`${IMAGE_BUCKET_URL}/magnifier-icon.png`}
+                alt=""
+              />
+            </div>
+            <input
+              name="searchBar"
+              value={inputValue.searchBar}
+              onChange={handleChange}
+            />
+          </form>
+        )}
         <div className={cx('btns')}>
           {loggedIn ? (
             <>
@@ -70,6 +84,12 @@ const Header = () => {
               />
               {showsDropdown && <DropdownMenu onClick={toggleDropdownMenu} />}
             </>
+          ) : isMobile ? (
+            <img
+              src={`${IMAGE_BUCKET_URL}/user-icon.png`}
+              className={cx('user-icon')}
+              onClick={openSigninModal}
+            />
           ) : (
             <>
               <CommonBtn

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -9,49 +9,34 @@
   position: fixed;
   top: 0;
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-end;
   align-items: center;
   width: 100%;
   height: inherit;
-  padding: 0 2rem;
+  padding: 0 0.5rem;
   background: #fff;
-  border: 1px solid #d4d4d4;
+  border: none;
+  border-bottom: 1px solid #d4d4d4;
   z-index: 100;
 
   .title {
+    position: absolute;
+    top: 0;
+    left: 1rem;
     display: flex;
-    flex: 1;
-    h1 {
-      color: $main-color;
-      font-size: 5rem;
-      font-weight: bold;
-      font-family: 'godoMaum';
-      white-space: nowrap;
-      &:hover {
-        color: $main-color-light;
-      }
+    justify-content: center;
+    align-items: center;
+    width: 5.6rem;
+    height: 100%;
+    img {
+      max-width: 100%;
     }
   }
 
-  form {
-    display: flex;
-    justify-content: center;
-    flex: 1;
-    width: 30rem;
-    height: 3rem;
-  }
-
-  .searchbar-icon-wrapper {
-    position: relative;
-  }
-
   .searchbar-icon {
-    position: absolute;
-    top: 50%;
-    left: 0.75rem;
-    transform: translateY(-50%);
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 4.5rem;
+    height: 4.5rem;
+    padding: 1rem;
   }
 
   input {
@@ -63,19 +48,68 @@
     font-size: 1.75rem;
   }
 
-  .profile-img {
-    &:hover {
-      box-shadow: 0 0 5px $main-color;
-    }
-  }
-
   .over-dropdown-background {
     z-index: 1000;
   }
 
   .btns {
-    flex: 1;
     display: flex;
     justify-content: flex-end;
+  }
+  .user-icon {
+    width: 4rem;
+    height: 4rem;
+    padding: 0.5rem;
+  }
+  .profile-img {
+    width: 4.5rem;
+    height: 4.5rem;
+    &:hover {
+      box-shadow: 0 0 5px $main-color;
+    }
+  }
+}
+@include tablet-and-desktop {
+  .header {
+    padding: 0 2rem 0 0;
+    .title {
+      position: relative;
+      width: auto;
+      flex: 1;
+      h1 {
+        color: $main-color;
+        font-size: 5rem;
+        font-weight: bold;
+        font-family: 'godoMaum';
+        white-space: nowrap;
+        &:hover {
+          color: $main-color-light;
+        }
+      }
+    }
+
+    form {
+      display: flex;
+      justify-content: center;
+      flex: 1.5;
+      max-width: 90%;
+      height: 3.5rem;
+    }
+
+    .searchbar-icon-wrapper {
+      position: relative;
+    }
+    .searchbar-icon {
+      position: absolute;
+      top: 50%;
+      left: 0.75rem;
+      transform: translateY(-50%);
+      width: 1.5rem;
+      height: 1.5rem;
+      padding: 0;
+    }
+    .btns {
+      flex: 1;
+    }
   }
 }

--- a/src/components/MapView/InfoWindow.scss
+++ b/src/components/MapView/InfoWindow.scss
@@ -1,9 +1,11 @@
+@import '../../stylesheets/util.scss';
+
 .wrapper {
   position: relative;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  width: 28rem;
+  width: 24rem;
   height: 12rem;
   transform: translate(1rem, -14rem);
   padding: 1.5rem;
@@ -29,7 +31,7 @@
 
   .location-name {
     margin: 0;
-    font-size: 2rem;
+    font-size: $small-title-font-size;
     display: inline-block;
 
     > a {
@@ -46,6 +48,7 @@
     left: 12rem;
     transform: translate(5px, -2px);
     height: 5rem;
+    pointer-events: none;
     &:hover {
       cursor: default;
     }
@@ -55,5 +58,11 @@
     position: absolute;
     top: 0rem;
     right: 0.5rem;
+  }
+}
+
+@include tablet-and-desktop {
+  .wrapper {
+    width: 28rem;
   }
 }

--- a/src/components/MapView/MapView.jsx
+++ b/src/components/MapView/MapView.jsx
@@ -2,18 +2,20 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { KakaoMap, Marker, CustomOverlay } from 'react-kakao-maps';
 import InfoWindow from '../MapView/InfoWindow';
+import useMediaQuerySet from '../../hooks/useMediaQuerySet';
 
 const MapView = ({
   data: { location: { latitude, longitude, ...info } = {} }
 }) => {
   const [infoDisplay, setInfoDisplay] = useState(true);
+  const { isMobile } = useMediaQuerySet();
 
   return (
     <KakaoMap
       // eslint-disable-next-line no-undef
       apiUrl={KAKAO_MAP_API_URL}
-      width="800px"
-      height="500px"
+      width={isMobile ? '95%' : '700px'}
+      height={isMobile ? '300px' : '450px'}
       level={2}
       lat={latitude}
       lng={longitude}

--- a/src/components/OAuthBtn/OAuthBtn.scss
+++ b/src/components/OAuthBtn/OAuthBtn.scss
@@ -1,15 +1,18 @@
 @import '../../stylesheets/util.scss';
 
+//link에 크기를 지정하지 않으면 버튼 좌우로 약간 삐져나오는 현상이 있어 link에 크기를 지정함.
 .link {
   display: inline-block;
-  width: 30rem;
   height: 4.2rem;
-  margin: 1.5rem;
+  margin: 1.5rem 0;
 }
 
 .btn {
   margin: 0;
-  width: 30rem;
+  padding-left: 0;
+  padding-right: 0;
+  width: 82vw;
+  max-width: 30rem;
 
   span {
     font-size: 1.5rem;

--- a/src/components/PostContainer/PostContainer.scss
+++ b/src/components/PostContainer/PostContainer.scss
@@ -1,13 +1,23 @@
-.main {
-  display: grid;
-  justify-items: center;
-  grid-template-columns: 50% 50%;
-  row-gap: 8rem;
-  width: 94rem;
-  padding: 2rem 0;
-}
+@import '../../stylesheets/util.scss';
+
 .wrapper {
   display: flex;
   justify-content: center;
   width: 100%;
+}
+
+.main {
+  display: grid;
+  justify-items: center;
+  grid-template-columns: 100%;
+  width: 100%;
+  row-gap: 2rem;
+}
+
+@include tablet-and-desktop {
+  .main {
+    grid-template-columns: 50% 50%;
+    width: 94rem;
+    row-gap: 8rem;
+  }
 }

--- a/src/components/PostItem/PostItem.scss
+++ b/src/components/PostItem/PostItem.scss
@@ -1,11 +1,12 @@
 @import '../../stylesheets/util.scss';
 
 .wrapper {
-  width: 40rem;
-  border: 1px solid #d4d4d4;
-  border-radius: 5px;
   justify-self: center;
   align-self: center;
+  max-width: 40rem;
+  margin: 0.5rem;
+  border: 1px solid #d4d4d4;
+  border-radius: 5px;
   background-color: #fff;
   &:hover {
     cursor: pointer;

--- a/src/components/PostUploader/DescriptionUploader.scss
+++ b/src/components/PostUploader/DescriptionUploader.scss
@@ -10,7 +10,7 @@ $color-red: rgb(255, 80, 80);
 .text-area {
   width: 100%;
   height: 10rem;
-  font-size: 2.4rem;
+  font-size: $small-title-font-size;
   border: 1px solid $gray-border-color;
 }
 

--- a/src/components/PostUploader/ImageUploader/ImageEditor/EditorFooter.scss
+++ b/src/components/PostUploader/ImageUploader/ImageEditor/EditorFooter.scss
@@ -6,8 +6,8 @@
 }
 
 button.btns {
-  flex-grow: 1;
   margin: 0;
+  width: 50%;
   border: none;
   border-top: 1px solid $gray-border-color;
   cursor: default;

--- a/src/components/PostUploader/ImageUploader/ImageEditor/EditorHeader.scss
+++ b/src/components/PostUploader/ImageUploader/ImageEditor/EditorHeader.scss
@@ -6,8 +6,8 @@
 }
 
 button.btns {
-  flex-grow: 1;
   margin: 0;
+  width: 50%;
   border: none;
   border-bottom: 1px solid $gray-border-color;
   cursor: default;

--- a/src/components/PostUploader/ImageUploader/ImageEditor/ImageEditor.jsx
+++ b/src/components/PostUploader/ImageUploader/ImageEditor/ImageEditor.jsx
@@ -6,6 +6,7 @@ import EditorHeader from './EditorHeader';
 import EditorFooter from './EditorFooter';
 import 'cropperjs/dist/cropper.css';
 import { asyncPipe } from '../../../../utils/utils';
+import useMediaQuerySet from '../../../../hooks/useMediaQuerySet';
 
 const cx = classNames.bind(styles);
 
@@ -23,6 +24,7 @@ const ImageEditor = ({
   targetIndex,
   onClose
 }) => {
+  const { isMobile } = useMediaQuerySet();
   const [cropper, setCropper] = useState(null);
   const ref = cropper => setCropper(cropper);
 
@@ -58,7 +60,11 @@ const ImageEditor = ({
           <Cropper
             ref={ref}
             src={src}
-            style={{ width: '450px', height: '450px' }}
+            style={
+              isMobile
+                ? { width: '100%', height: '60vh' }
+                : { width: '450px', height: '450px' }
+            }
             checkOrientation={false}
             aspectRatio={1 / 1}
             autoCropArea={1}

--- a/src/components/PostUploader/ImageUploader/ImageEditor/ImageEditor.scss
+++ b/src/components/PostUploader/ImageUploader/ImageEditor/ImageEditor.scss
@@ -1,7 +1,16 @@
+@import '../../../../stylesheets/util.scss';
+
 .wrapper {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  width: 50rem;
+  width: 99vw;
+  min-height: auto;
+}
+
+@include tablet-and-desktop {
+  .wrapper {
+    max-width: 47rem;
+  }
 }

--- a/src/components/PostUploader/ImageUploader/ImageUploader.scss
+++ b/src/components/PostUploader/ImageUploader/ImageUploader.scss
@@ -3,5 +3,5 @@
   justify-content: space-around;
   flex-wrap: wrap;
   margin-bottom: 2rem;
-  width: 60rem;
+  max-width: 60rem;
 }

--- a/src/components/PostUploader/ImageUploader/OverlayButtons.scss
+++ b/src/components/PostUploader/ImageUploader/OverlayButtons.scss
@@ -1,13 +1,21 @@
+@import '../../../stylesheets/util.scss';
+
 .btn-wrapper {
   display: flex;
   justify-content: center;
   position: absolute;
   top: 4px;
   left: 0;
-  width: 15rem;
+  width: 10rem;
 }
 
 .btns {
   margin: 0 1px;
   width: 2.2rem;
+}
+
+@include tablet-and-desktop {
+  .btn-wrapper {
+    width: 15rem;
+  }
 }

--- a/src/components/PostUploader/ImageUploader/PreviewImages.jsx
+++ b/src/components/PostUploader/ImageUploader/PreviewImages.jsx
@@ -7,7 +7,7 @@ import useMediaQuerySet from '../../../hooks/useMediaQuerySet';
 const cx = classNames.bind(styles);
 
 const PreviewImages = ({ images, onDelete, onSelect, openEditor }) => {
-  const { isMobile } = useMediaQuerySet();
+  const { isDesktop } = useMediaQuerySet();
   const [hoveredImageIdx, setHoveredImageIdx] = useState(null);
   const [hoveredButtonIdx, setHoveredButtonIdx] = useState(null);
 
@@ -39,7 +39,7 @@ const PreviewImages = ({ images, onDelete, onSelect, openEditor }) => {
           onMouseEnter={handleImageMouseEnter}
           onMouseLeave={handleImageMouseLeave}
         />
-        {(isMobile || isImageHovered || isButtonHovered) && (
+        {(!isDesktop || isImageHovered || isButtonHovered) && (
           <OverlayButtons
             index={index}
             onMouseEnter={handleButtonMouseEnter}

--- a/src/components/PostUploader/ImageUploader/PreviewImages.jsx
+++ b/src/components/PostUploader/ImageUploader/PreviewImages.jsx
@@ -2,10 +2,12 @@ import React, { useState } from 'react';
 import classNames from 'classnames/bind';
 import styles from './PreviewImages.scss';
 import OverlayButtons from './OverlayButtons';
+import useMediaQuerySet from '../../../hooks/useMediaQuerySet';
 
 const cx = classNames.bind(styles);
 
 const PreviewImages = ({ images, onDelete, onSelect, openEditor }) => {
+  const { isMobile } = useMediaQuerySet();
   const [hoveredImageIdx, setHoveredImageIdx] = useState(null);
   const [hoveredButtonIdx, setHoveredButtonIdx] = useState(null);
 
@@ -37,7 +39,7 @@ const PreviewImages = ({ images, onDelete, onSelect, openEditor }) => {
           onMouseEnter={handleImageMouseEnter}
           onMouseLeave={handleImageMouseLeave}
         />
-        {(isImageHovered || isButtonHovered) && (
+        {(isMobile || isImageHovered || isButtonHovered) && (
           <OverlayButtons
             index={index}
             onMouseEnter={handleButtonMouseEnter}

--- a/src/components/PostUploader/ImageUploader/PreviewImages.scss
+++ b/src/components/PostUploader/ImageUploader/PreviewImages.scss
@@ -1,5 +1,8 @@
 @import '../../../stylesheets/util.scss';
 
+$mobile-preview-size: 10rem;
+$desktop-preview-size: 15rem;
+
 .wrapper {
   position: relative;
   margin: 0 1rem;
@@ -7,11 +10,18 @@
 }
 
 .img {
-  width: 15rem;
-  height: 15rem;
+  width: $mobile-preview-size;
+  height: $mobile-preview-size;
   border: 1px solid $main-color-light;
 
   &.representative {
     border: 3px solid $main-color-light;
+  }
+}
+
+@include tablet-and-desktop {
+  .img {
+    width: $desktop-preview-size;
+    height: $desktop-preview-size;
   }
 }

--- a/src/components/PostUploader/ImageUploader/SecondInputButton.scss
+++ b/src/components/PostUploader/ImageUploader/SecondInputButton.scss
@@ -1,22 +1,28 @@
 @import '../../../stylesheets/util.scss';
 
+$mobile-preview-size: 10rem;
+$desktop-preview-size: 15rem;
+
 .wrapper {
-  width: 15rem;
-  height: 15rem;
-  border: 2px dashed $main-color-light;
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 0 1rem;
+  width: $mobile-preview-size;
+  height: $mobile-preview-size;
+  border: 2px dashed $main-color-light;
 }
 
 .label {
   display: inline-block;
-  padding: 1.5rem 2rem;
+  width: 6rem;
+  height: 6rem;
   border-radius: 50%;
   background-color: $main-color-light;
   color: white;
   font-size: 3rem;
-  line-height: normal;
+  text-align: center;
+  line-height: 6rem;
   cursor: pointer;
 }
 
@@ -24,4 +30,11 @@
   display: none;
   width: 0;
   height: 0;
+}
+
+@include tablet-and-desktop {
+  .wrapper {
+    width: $desktop-preview-size;
+    height: $desktop-preview-size;
+  }
 }

--- a/src/components/PostUploader/LocationUploader/LocationFinder.jsx
+++ b/src/components/PostUploader/LocationUploader/LocationFinder.jsx
@@ -11,6 +11,7 @@ import SearchResultLists from './SearchResultLists';
 import SearchResultMarkers from './SearchResultMarkers';
 import LocationFinderPopupMessage from './LocationFinderPopupMessage';
 import { IMAGE_BUCKET_URL } from '../../../configs';
+import useMediaQuerySet from '../../../hooks/useMediaQuerySet';
 
 const cx = classNames.bind(styles);
 
@@ -22,8 +23,10 @@ const LocationFinder = ({
   setSelectedLocation,
   setReadyToUpload
 }) => {
+  const { isMobile } = useMediaQuerySet();
   const { inputValue, handleChange } = useInput();
   const { locationKeyword } = inputValue;
+
   //kakao => 카카오 스크립트 태그를 통해 전역에 생성된 kakao객체의 인스턴스.
   //map => new kakao.maps.Map()을 통해 생성된 지도객체 인스턴스.
   //카카오 지도를 표시하고 조작하기 위한 메서드가 정의되어 있음.
@@ -156,8 +159,8 @@ const LocationFinder = ({
         <KakaoMap
           // eslint-disable-next-line no-undef
           apiUrl={KAKAO_MAP_API_URL}
-          width="570px"
-          height="400px"
+          width={isMobile ? '95vw' : '570px'}
+          height={isMobile ? '300px' : '400px'}
           level={3}
           lat={INITIAL_LAT}
           lng={INITIAL_LNG}

--- a/src/components/PostUploader/LocationUploader/LocationFinder.scss
+++ b/src/components/PostUploader/LocationUploader/LocationFinder.scss
@@ -3,55 +3,67 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  width: 80rem;
+  width: 100%;
   background-color: #fff;
   border: 1px solid $gray-border-color;
   border-radius: 5px;
+}
+.search-icon {
+  margin: 1rem;
+  width: 2rem;
+  height: 2rem;
+}
 
-  .search-icon {
-    margin: 1rem;
-    width: 2rem;
-    height: 2rem;
-  }
+.header {
+  display: flex;
+  height: 4rem;
 
-  .header {
+  form {
     display: flex;
-    height: 4rem;
-
-    form {
-      display: flex;
-      align-items: center;
-      width: 100%;
-      border-right: 1px solid $gray-border-color;
-    }
-
-    input {
-      width: 100%;
-      height: 100%;
-      border: 0;
-      font-size: 1.6rem;
-      &:focus {
-        outline: none;
-      }
-    }
+    align-items: center;
+    width: 100%;
+    border-right: 1px solid $gray-border-color;
   }
 
+  input {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    font-size: 1.6rem;
+    &:focus {
+      outline: none;
+    }
+  }
+}
+
+.content {
+  display: flex;
+  flex-direction: column-reverse;
+  height: 80vh;
+  border-top: 1px solid $gray-border-color;
+  border-bottom: 1px solid $gray-border-color;
+}
+
+.search-result {
+  flex: 1;
+  border-right: 1px solid $gray-border-color;
+  overflow: auto;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@include tablet-and-desktop {
+  .wrapper {
+    width: 80rem;
+  }
   .content {
-    display: flex;
+    flex-direction: row;
     height: 40rem;
-    border-top: 1px solid $gray-border-color;
-    border-bottom: 1px solid $gray-border-color;
   }
-
   .search-result {
     height: 100%;
-    flex: 1;
-    border-right: 1px solid $gray-border-color;
-    overflow: auto;
-  }
-
-  .footer {
-    display: flex;
-    justify-content: flex-end;
   }
 }

--- a/src/components/PostUploader/LocationUploader/LocationFinderPopupMessage.scss
+++ b/src/components/PostUploader/LocationUploader/LocationFinderPopupMessage.scss
@@ -12,26 +12,34 @@
   justify-content: center;
   align-items: center;
   padding: 1rem 3rem;
+  width: 99vw;
 
   background-color: #fff;
   border: 1px solid $main-color;
   border-radius: 5px;
   box-shadow: 0 0 15px #999999;
+}
+.message {
+  color: $main-color;
+  font-family: 'godoMaum';
+  font-size: $medium-title-font-size;
+  line-height: 4rem;
+}
 
-  .message {
-    color: $main-color;
-    font-family: 'godoMaum';
-    font-size: 3.2rem;
-    line-height: 4rem;
-    white-space: nowrap;
+.buttons {
+  display: flex;
+  width: 80%;
+
+  > button {
+    width: 40%;
   }
+}
 
-  .buttons {
-    display: flex;
-    width: 80%;
-
-    > button {
-      width: 40%;
-    }
+@include tablet-and-desktop {
+  .wrapper {
+    width: auto;
+  }
+  .message {
+    white-space: nowrap;
   }
 }

--- a/src/components/PostUploader/LocationUploader/LocationPreview.jsx
+++ b/src/components/PostUploader/LocationUploader/LocationPreview.jsx
@@ -2,9 +2,11 @@ import React, { useMemo, useEffect } from 'react';
 import { KakaoMap } from 'react-kakao-maps';
 import Marker from './react-kakao-maps/Marker';
 import useMapContext from './react-kakao-maps/hooks/useMapContext';
+import useMediaQuerySet from '../../../hooks/useMediaQuerySet';
 
 const LocationPreview = ({ lat, lng, onClick: openLocationFinder }) => {
   const { MapContextForwarder, kakao, map } = useMapContext();
+  const { isMobile } = useMediaQuerySet();
 
   useMemo(() => {
     if (!map) return;
@@ -28,8 +30,8 @@ const LocationPreview = ({ lat, lng, onClick: openLocationFinder }) => {
     <KakaoMap
       // eslint-disable-next-line no-undef
       apiUrl={KAKAO_MAP_API_URL}
-      width="600px"
-      height="200px"
+      width={isMobile ? '100%' : '600px'}
+      height={isMobile ? '150px' : '200px'}
       level={3}
       lat={lat}
       lng={lng}

--- a/src/components/PostUploader/TitleUploader.jsx
+++ b/src/components/PostUploader/TitleUploader.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import classNames from 'classnames/bind';
 import styles from './TitleUploader.scss';
 import useInput from '../../hooks/useInput';
+import useMediaQuerySet from '../../hooks/useMediaQuerySet';
 
 const cx = classNames.bind(styles);
 
@@ -11,6 +12,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
     setInputValue,
     handleChange: handleInputChange
   } = useInput(title);
+  const { isDesktop } = useMediaQuerySet();
   const { place, companion, activity } = inputValue;
   const [locationInputStyle, setLocationInputStyle] = useState({});
 
@@ -77,7 +79,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
 
   useEffect(() => {
     if (!(place || companion || activity)) return;
-    adjustLocationInputWidth(place);
+    isDesktop && adjustLocationInputWidth(place);
     setTitle({
       place,
       companion,
@@ -97,6 +99,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
           placeholder="어디"
           name="place"
           value={place}
+          className={cx('text-boxes')}
           onChange={handleInputChange}
           style={locationInputStyle}
         />
@@ -107,6 +110,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
           type="text"
           placeholder="누구랑"
           name="companion"
+          className={cx('text-boxes')}
           value={companion}
           onChange={handleInputChange}
           onFocus={setInputStateFocused}
@@ -114,7 +118,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
         />
         {(isOverlayHovered || isCompanionInputFocused) && (
           <select
-            className={cx('overlay-select-box')}
+            className={cx('overlay-select-box', 'text-boxes')}
             name="companion"
             value={select}
             onChange={handleSelectBoxChange}
@@ -135,6 +139,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
         type="text"
         placeholder="뭐하기"
         name="activity"
+        className={cx('text-boxes')}
         value={activity}
         onChange={handleInputChange}
       />

--- a/src/components/PostUploader/TitleUploader.jsx
+++ b/src/components/PostUploader/TitleUploader.jsx
@@ -5,17 +5,6 @@ import useInput from '../../hooks/useInput';
 
 const cx = classNames.bind(styles);
 
-const companionValues = {
-  ALONE: '혼자서',
-  FRIENDS: '친구랑',
-  COUPLE: '연인이랑',
-  FAMILY: '가족이랑'
-};
-
-const isFreeInputValue = val => {
-  return val && !Object.values(companionValues).some(value => value === val);
-};
-
 const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
   const {
     inputValue,
@@ -27,7 +16,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
 
   const [select, setSelect] = useState(companion || '');
   const [state, setState] = useState({});
-  const { showsFreeInput, isCompanionInputFocused, isOverlayHovered } = state;
+  const { isCompanionInputFocused, isOverlayHovered } = state;
 
   const handleSelectBoxChange = ({ target }) => {
     setSelect(target.value);
@@ -82,12 +71,8 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
 
   useEffect(() => {
     if (!select) return;
-    if (isFreeInputValue(select)) {
-      setState({ ...state, showsFreeInput: true });
-    } else {
-      setInputValue({ ...inputValue, companion: select });
-      setState({});
-    }
+    setInputValue({ ...inputValue, companion: select });
+    setState({});
   }, [select]);
 
   useEffect(() => {
@@ -118,33 +103,16 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
         <span>에서</span>
       </div>
       <span className={cx('companion-section')}>
-        {showsFreeInput ? (
-          <input
-            type="text"
-            placeholder="누구랑"
-            name="companion"
-            value={companion}
-            onChange={handleInputChange}
-            onFocus={setInputStateFocused}
-            onBlur={setInputStateBlurred}
-          />
-        ) : (
-          <select
-            name="companion"
-            value={select}
-            onChange={handleSelectBoxChange}
-          >
-            <option value="" disabled>
-              누구랑
-            </option>
-            <option value="혼자서">혼자서</option>
-            <option value="친구랑">친구랑</option>
-            <option value="연인이랑">연인이랑</option>
-            <option value="가족이랑">가족이랑</option>
-            <option value="직접입력">직접입력</option>
-          </select>
-        )}
-        {isOverlayHovered || isCompanionInputFocused ? (
+        <input
+          type="text"
+          placeholder="누구랑"
+          name="companion"
+          value={companion}
+          onChange={handleInputChange}
+          onFocus={setInputStateFocused}
+          onBlur={setInputStateBlurred}
+        />
+        {(isOverlayHovered || isCompanionInputFocused) && (
           <select
             className={cx('overlay-select-box')}
             name="companion"
@@ -153,7 +121,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
             onMouseOver={setOverlayStateHovered}
             onMouseLeave={setOverlayStateUnhovered}
           >
-            <option value="직접입력" disabled>
+            <option value="_default" disabled>
               누구랑
             </option>
             <option value="혼자서">혼자서</option>
@@ -161,7 +129,7 @@ const TitleUploader = ({ placeName, title, setTitle, setReadyToUpload }) => {
             <option value="연인이랑">연인이랑</option>
             <option value="가족이랑">가족이랑</option>
           </select>
-        ) : null}
+        )}
       </span>
       <input
         type="text"

--- a/src/components/PostUploader/TitleUploader.scss
+++ b/src/components/PostUploader/TitleUploader.scss
@@ -5,47 +5,71 @@
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  height: 20rem;
   margin: 2rem 0;
+  width: 100%;
+  height: 20rem;
+}
 
-  input {
-    width: 90vw;
-    height: 5rem;
+.text-boxes {
+  width: 100%;
+  height: 5rem;
+  border: none;
+  border-bottom: 1px solid $gray-border-color;
+  font-size: $medium-title-font-size;
+  text-align: center;
+}
+
+.place-section {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+
+  > .text-boxes {
+    flex: 1;
+  }
+  > span {
     font-size: $medium-title-font-size;
-    border: none;
-    border-bottom: 1px solid $gray-border-color;
-    text-align: center;
   }
+}
 
+.companion-section {
+  display: flex;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+}
+
+.overlay-select-box {
+  position: absolute;
+  top: 4rem;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 0.5rem;
+
+  width: 100%;
+
+  border: 1px solid #999;
+  border-radius: 5px;
+  background-color: #fff;
+  font-size: $medium-title-font-size;
+  text-align-last: center;
+}
+
+@include tablet-and-desktop {
+  .wrapper {
+    max-width: 80%;
+  }
+}
+
+@include desktop {
   .place-section {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    > input {
-      width: 75vw;
-    }
-    > span {
-      font-size: $medium-title-font-size;
-    }
+    width: auto;
   }
-
-  .companion-section {
-    position: relative;
-
-    > select {
-      width: 90vw;
-      border: 1px solid;
-      border-radius: 5px;
-      background-color: #fff;
-      font-size: $medium-title-font-size;
-      text-align-last: center;
-    }
+  .text-boxes {
+    width: auto;
   }
-
   .overlay-select-box {
-    position: absolute;
-    top: 4rem;
-    left: 0;
-    margin-top: 0.5rem;
+    width: 30rem;
   }
 }

--- a/src/components/PostUploader/TitleUploader.scss
+++ b/src/components/PostUploader/TitleUploader.scss
@@ -33,7 +33,10 @@
     position: relative;
 
     > select {
-      width: 20rem;
+      width: 90vw;
+      border: 1px solid;
+      border-radius: 5px;
+      background-color: #fff;
       font-size: $medium-title-font-size;
       text-align-last: center;
     }

--- a/src/components/PostUploader/TitleUploader.scss
+++ b/src/components/PostUploader/TitleUploader.scss
@@ -9,17 +9,23 @@
   margin: 2rem 0;
 
   input {
-    width: 20rem;
+    width: 90vw;
     height: 5rem;
-    font-size: 3.2rem;
+    font-size: $medium-title-font-size;
     border: none;
     border-bottom: 1px solid $gray-border-color;
     text-align: center;
   }
 
   .place-section {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    > input {
+      width: 75vw;
+    }
     > span {
-      font-size: 3.2rem;
+      font-size: $medium-title-font-size;
     }
   }
 
@@ -28,7 +34,7 @@
 
     > select {
       width: 20rem;
-      font-size: 3.2rem;
+      font-size: $medium-title-font-size;
       text-align-last: center;
     }
   }

--- a/src/components/ProfileContentItem/ProfileContentItem.jsx
+++ b/src/components/ProfileContentItem/ProfileContentItem.jsx
@@ -12,12 +12,7 @@ const ProfileContentItem = props => {
     <div className={cx('content-item')}>
       <label>{label}</label>
       <input type="text" name={name} value={value} onChange={changeHandler} />
-      {nicknameValidity && (
-        <ValidityMessage
-          messageKey={nicknameValidity}
-          styleObj={{ fontSize: '1.5rem' }}
-        />
-      )}
+      {nicknameValidity && <ValidityMessage messageKey={nicknameValidity} />}
     </div>
   );
 };

--- a/src/components/ProfileContentItem/ProfileContentItem.scss
+++ b/src/components/ProfileContentItem/ProfileContentItem.scss
@@ -8,7 +8,6 @@
   margin-top: 2rem;
   width: 100%;
   font-size: 1.6rem;
-  line-height: 3rem;
 
   > label {
     padding-left: 0.5rem;
@@ -18,6 +17,7 @@
 
   > input {
     width: 100%;
+    height: 4rem;
     border: 1px solid $gray-border-color;
     border-radius: 5px;
     padding-left: 1rem;
@@ -35,6 +35,7 @@
 @include desktop {
   .content-item {
     flex-direction: row;
+    align-items: center;
 
     > label {
       padding-right: 2rem;

--- a/src/components/ProfileContentItem/ProfileContentItem.scss
+++ b/src/components/ProfileContentItem/ProfileContentItem.scss
@@ -1,24 +1,25 @@
 @import '../../stylesheets/util.scss';
 
 .content-item {
+  position: relative; //ValidityMessage 포지셔닝을 위한 속성
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 2rem;
+  width: 100%;
   font-size: 1.6rem;
   line-height: 3rem;
-  margin-top: 2rem;
-  display: flex;
-  align-items: center;
-  position: relative;
 
   > label {
+    padding-left: 0.5rem;
     font-weight: bold;
-    width: 20%;
     text-align: right;
-    padding-right: 2rem;
   }
 
   > input {
-    width: 80%;
+    width: 100%;
     border: 1px solid $gray-border-color;
-    border-radius: 0.3rem;
+    border-radius: 5px;
     padding-left: 1rem;
 
     &:hover {
@@ -27,6 +28,20 @@
 
     &:focus {
       outline: none;
+    }
+  }
+}
+
+@include desktop {
+  .content-item {
+    flex-direction: row;
+
+    > label {
+      padding-right: 2rem;
+      width: 20%;
+    }
+    > input {
+      width: 80%;
     }
   }
 }

--- a/src/components/ProfileInfo/ProfileInfo.scss
+++ b/src/components/ProfileInfo/ProfileInfo.scss
@@ -2,12 +2,12 @@
 
 .wrapper {
   display: grid;
-  grid-template-columns: 25% 25% 50%;
-  grid-template-areas: '. left right';
+  grid-template-columns: 50% 50%;
+  grid-template-areas: 'left right';
   margin: 0 auto;
-  padding: 5rem 0 2rem 0;
-  width: 94rem;
-  height: 27rem;
+  padding: 2rem 0 2rem 0;
+  width: 100%;
+  height: 24rem;
 
   .left-column {
     grid-area: left;
@@ -15,6 +15,7 @@
     justify-content: space-around;
     align-items: center;
     flex-direction: column;
+    justify-self: end;
   }
 
   .right-column {
@@ -22,6 +23,7 @@
     display: flex;
     justify-content: space-evenly;
     flex-direction: column;
+    padding-left: 2rem;
   }
 
   .header {
@@ -51,5 +53,11 @@
   .introduction {
     font-size: 1.6rem;
     padding: 1rem 0;
+  }
+}
+
+@include tablet-and-desktop {
+  .left-column {
+    padding-right: 2rem;
   }
 }

--- a/src/components/RelatedPost/RelatedPost.jsx
+++ b/src/components/RelatedPost/RelatedPost.jsx
@@ -29,7 +29,6 @@ const RelatedPost = ({ postId }) => {
   );
   const updateWindowWidth = useCallback(
     throttle(() => {
-      console.log('mobile');
       setWindowViewportWidth(window.innerWidth);
     }),
     []

--- a/src/components/RelatedPost/RelatedPost.jsx
+++ b/src/components/RelatedPost/RelatedPost.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import classNames from 'classnames/bind';
 import styles from './RelatedPost.scss';
 import useFetch from '../../hooks/useFetch';
+import useMediaQuerySet from '../../hooks/useMediaQuerySet';
 import RelatedPostComment from './RelatedPostComment';
+import { throttle } from '../../utils/utils';
 import {
   TRANSITION_DURATION_TIME,
   TRANSITION_DELAY_TIME,
@@ -12,6 +14,27 @@ import {
 const cx = classNames.bind(styles);
 
 const RelatedPost = ({ postId }) => {
+  const { isMobile } = useMediaQuerySet();
+  const [windowWidth, setWindowViewportWidth] = useState(window.innerWidth);
+  //아래 계산식은 RelatedPost.scss 내에 작성된 계산식에 의존함.
+  const carouselWidthOverMobile = 500; //px
+  const btnSize = 20; //px
+  const padding = 10; //px
+  const carouselViewportWidth = useMemo(
+    () =>
+      isMobile
+        ? windowWidth - (padding + btnSize) * 2
+        : carouselWidthOverMobile,
+    [windowWidth]
+  );
+  const updateWindowWidth = useCallback(
+    throttle(() => {
+      console.log('mobile');
+      setWindowViewportWidth(window.innerWidth);
+    }),
+    []
+  );
+
   const [currentActiveIndex, setCurrentActiveIndex] = useState(1);
   const [positionX, setPositionX] = useState(0);
   const [page, setPage] = useState(1);
@@ -52,10 +75,9 @@ const RelatedPost = ({ postId }) => {
   };
 
   const makeCarouselJsx = () => {
-    const len = posts.length;
-    return !len ? (
+    return !posts.length ? (
       <div className={cx('carousel-wrap')}>
-        <h3>아직 이 장소를 방문한 다른 사람이 없네요. 🥺</h3>;
+        <h3>아직 이 장소를 방문한 다른 사람이 없네요. 🥺</h3>
       </div>
     ) : (
       <div
@@ -79,7 +101,7 @@ const RelatedPost = ({ postId }) => {
   const prevBtnHandler = () => {
     if (currentActiveIndex === 1) return;
     setCurrentActiveIndex(currentActiveIndex - 1);
-    setPositionX(positionX + 500);
+    setPositionX(positionX + carouselViewportWidth);
   };
 
   const nextBtnHandler = () => {
@@ -88,25 +110,33 @@ const RelatedPost = ({ postId }) => {
     if (response.hasNextPage && currentActiveIndex === maximumIndex - 1)
       setPage(page + 1);
     setCurrentActiveIndex(currentActiveIndex + 1);
-    setPositionX(positionX - 500);
+    setPositionX(positionX - carouselViewportWidth);
   };
+
+  useEffect(() => {
+    window.addEventListener('resize', updateWindowWidth);
+    return () => {
+      window.removeEventListener('resize', updateWindowWidth);
+    };
+  }, [isMobile]);
 
   return (
     <div className={cx('wrapper')}>
       <hr />
       <h2 className={cx('header')}>이 장소를 방문한 사람들</h2>
-
-      <div className={cx('carousel')}>{makeCarouselJsx()}</div>
-      {posts.length > 5 && (
-        <div className={cx('carousel-btns')}>
+      <div className={cx('carousel-area')}>
+        {posts.length > 5 && (
           <button className={cx('prev-btn')} onClick={prevBtnHandler}>
             &lt;
           </button>
+        )}
+        <div className={cx('carousel')}>{makeCarouselJsx()}</div>
+        {posts.length > 5 && (
           <button className={cx('next-btn')} onClick={nextBtnHandler}>
             &gt;
           </button>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/RelatedPost/RelatedPost.scss
+++ b/src/components/RelatedPost/RelatedPost.scss
@@ -1,41 +1,65 @@
-.wrapper {
-  width: 700px;
-  position: relative;
+@import '../../stylesheets/util.scss';
 
-  .header {
-    text-align: center;
-    font-size: 2.8rem;
-    margin: 2rem 0;
+//아래 변수들 수정 시 RelatedPost.jsx의 변수 및 계산식도 수정해야 함.
+$btn-size: 2rem;
+$padding: 1rem;
+$carousel-width: calc(100vw - (#{$padding} + #{$btn-size}) * 2);
+
+.header {
+  margin: 2rem 0;
+  font-size: $medium-title-font-size;
+  letter-spacing: -1px;
+  text-align: center;
+}
+.carousel-area {
+  display: flex;
+  align-items: center;
+}
+.carousel {
+  display: flex;
+  margin: 0 auto;
+  width: $carousel-width;
+  overflow: hidden;
+}
+.carousel-wrap {
+  display: flex;
+  justify-content: space-evenly;
+}
+.prev-btn,
+.next-btn {
+  width: $btn-size;
+  height: $btn-size;
+  background-color: #fff;
+  border: 1px solid $gray-border-color;
+  border-radius: 50%;
+  cursor: auto !important;
+
+  &:active {
+    background-color: #aaa;
   }
+}
 
+@include tablet-and-desktop {
+  .header {
+    letter-spacing: normal;
+  }
+  .wrapper {
+    max-width: 700px;
+  }
   .carousel {
-    width: 500px;
-    overflow: hidden;
-    display: flex;
-    margin: 0 auto;
-
-    h3 {
-      text-align: center;
+    max-width: 500px;
+  }
+  .prev-btn,
+  .next-btn {
+    width: $btn-size * 2;
+    height: $btn-size * 2;
+  }
+}
+@include desktop {
+  .prev-btn,
+  .next-btn {
+    &:hover {
+      box-shadow: 0 0 5px $main-color;
     }
   }
-
-  .carousel-wrap {
-    display: flex;
-    justify-content: space-evenly;
-  }
-
-  .carousel-btns {
-    position: relative;
-    top: -10rem;
-  }
-}
-
-.prev-btn {
-  position: relative;
-  left: 2rem;
-}
-
-.next-btn {
-  position: absolute;
-  right: 3rem;
 }

--- a/src/components/RelatedPost/RelatedPostComment.jsx
+++ b/src/components/RelatedPost/RelatedPostComment.jsx
@@ -15,7 +15,11 @@ const RelatedPostComment = ({
   return (
     <div className={cx('wrapper')}>
       <CommonLink to={`/post/${postId}`}>
-        <ProfileImage medium src={profileImageURL} />
+        <ProfileImage
+          medium
+          src={profileImageURL}
+          className={cx('profile-image')}
+        />
       </CommonLink>
       <CommonLink to={`/post/${postId}`}>
         <h3 className={cx('comment')}>

--- a/src/components/RelatedPost/RelatedPostComment.scss
+++ b/src/components/RelatedPost/RelatedPostComment.scss
@@ -1,9 +1,33 @@
+@import '../../stylesheets/util.scss';
+@import './RelatedPost.scss';
+
+$carousel-item-wrapper-size: calc(#{$carousel-width}/ 5);
+$carousel-item-padding: 0.5rem;
+$carousel-item-size: calc(
+  #{$carousel-item-wrapper-size} - (#{$carousel-item-padding} * 2)
+);
+
+.wrapper {
+  text-align: center;
+  width: $carousel-item-wrapper-size;
+}
+
+.profile-image {
+  width: $carousel-item-size;
+  height: $carousel-item-size;
+}
+
 .comment {
   margin-top: 1.5rem;
   font-size: 1.4rem;
 }
 
-.wrapper {
-  text-align: center;
-  width: 100px;
+@include tablet-and-desktop {
+  .wrapper {
+    max-width: 10rem;
+  }
+  .profile-image {
+    max-width: 8rem;
+    max-height: 8rem;
+  }
 }

--- a/src/components/ValidityMessage/ValidityMessage.jsx
+++ b/src/components/ValidityMessage/ValidityMessage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames/bind';
 import styles from './ValidityMessage.scss';
+import useMediaQuerySet from '../../hooks/useMediaQuerySet';
 
 const cx = classNames.bind(styles);
 
@@ -11,18 +12,26 @@ const messageMap = {
   CURRENT_NICKNAME: '현재 닉네임이에요.',
   SERVER_ERROR: '서버에서 에러가 발생했어요. 잠시후에 다시 시도해주세요.',
   NO_MESSAGE: '',
-  INFO_MESSAGE: '영문으로 시작하는 4~15자의 영문, 숫자 조합을 만들어주세요.',
+  INFO_MESSAGE:
+    '영문으로 시작하는 4~15자의 영문,<br/> 숫자 조합을 만들어주세요.',
   INVALID_TOKEN: '유효한 토큰이 아니에요. 메인으로 돌아가서 다시 시도해주세요.',
-  INVALID_PHONE_NUMBER: '010-1234-5678 형식으로 입력해주세요.'
+  INVALID_PHONE_NUMBER: '010-1234-5678 형식으로<br/> 입력해주세요.'
 };
 
-const ValidityMessage = ({ messageKey, styleObj = {} }) => {
-  const valid =
-    messageKey === 'AVAILABLE' || messageKey === 'CURRENT_NICKNAME'
-      ? true
-      : false;
+const makeMessageLineByLine = (messageKey, isMobile) =>
+  messageKey &&
+  messageMap[messageKey].split('<br/>').map((line, idx) => (
+    <span key={idx}>
+      {line}
+      {isMobile ? <br /> : ''}
+    </span>
+  ));
 
-  const message = messageMap[messageKey];
+const ValidityMessage = ({ messageKey, styleObj = {} }) => {
+  const { isMobile } = useMediaQuerySet();
+  const valid = messageKey === 'AVAILABLE' || messageKey === 'CURRENT_NICKNAME';
+
+  const message = makeMessageLineByLine(messageKey, isMobile);
 
   return (
     <div className={cx('wrapper')} style={styleObj}>

--- a/src/components/ValidityMessage/ValidityMessage.scss
+++ b/src/components/ValidityMessage/ValidityMessage.scss
@@ -3,8 +3,10 @@
 .wrapper {
   display: flex;
   position: absolute;
-  bottom: 0.1rem;
-  right: 2rem;
+  bottom: 0.5rem;
+  right: 1rem;
+  font-size: 1.2rem;
+  text-align: end;
   pointer-events: none;
 }
 .ok-msg {
@@ -12,10 +14,4 @@
 }
 .not-ok-msg {
   color: red;
-}
-
-@include desktop {
-  .wrapper {
-    right: 1rem;
-  }
 }

--- a/src/components/ValidityMessage/ValidityMessage.scss
+++ b/src/components/ValidityMessage/ValidityMessage.scss
@@ -1,7 +1,10 @@
+@import '../../stylesheets/util.scss';
+
 .wrapper {
   display: flex;
   position: absolute;
-  right: 1rem;
+  bottom: 0.1rem;
+  right: 2rem;
   pointer-events: none;
 }
 .ok-msg {
@@ -9,4 +12,10 @@
 }
 .not-ok-msg {
   color: red;
+}
+
+@include desktop {
+  .wrapper {
+    right: 1rem;
+  }
 }

--- a/src/hooks/useMediaQuerySet.jsx
+++ b/src/hooks/useMediaQuerySet.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useMediaQuery } from 'react-responsive';
+
+const useMediaQuerySet = () => {
+  const isMobile = useMediaQuery({ maxWidth: 767 });
+  const isTablet = useMediaQuery({ minWidth: 768, maxWidth: 1199 });
+  const isDesktop = useMediaQuery({ minWidth: 1200 });
+  return { isDesktop, isTablet, isMobile };
+};
+
+export default useMediaQuerySet;

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/pages/DetailPage/DetailPage.scss
+++ b/src/pages/DetailPage/DetailPage.scss
@@ -5,15 +5,20 @@
   flex-direction: column;
   align-items: center;
   background-image: $sub-gradient;
+}
+.contents {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 5rem;
+  padding: 3rem 2rem;
+  background-color: #fff;
+  border-radius: 5px;
+  width: 100%;
+}
 
+@include tablet-and-desktop {
   .contents {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin: 5rem;
-    padding: 3rem 2rem;
-    background-color: #fff;
-    border-radius: 5px;
-    width: 95rem;
+    max-width: 95rem;
   }
 }

--- a/src/pages/MainPage/MainPage.scss
+++ b/src/pages/MainPage/MainPage.scss
@@ -3,28 +3,44 @@
 .wrapper {
   display: flex;
   flex-direction: column;
+}
+.banner {
+  position: relative;
+  width: 100%;
+  margin-bottom: 2.5rem;
+  background-image: $main-gradient;
+}
+.banner-text {
+  width: 100%;
+  padding: 3rem 5rem;
+  font-size: 3rem;
+  font-family: 'KCC-eunyoung';
+  color: #fff;
 
+  b {
+    color: $point-color;
+  }
+}
+
+@include tablet-and-desktop {
   .banner {
-    position: relative;
-    width: 100%;
-    height: 45rem;
     margin-bottom: 5rem;
-    background-image: $main-gradient;
-
-    &-text {
-      position: absolute;
-      top: 20rem;
-      right: 5rem;
-      width: 81rem;
-      padding: 0 5rem;
-      text-align: right;
-      font-size: 4rem;
-      font-family: 'KCC-eunyoung';
-      color: #fff;
-
-      b {
-        color: $point-color;
-      }
-    }
+    height: 45rem;
+  }
+  .banner-text {
+    position: absolute;
+    top: 20rem;
+    right: 5%;
+    text-align: right;
+  }
+}
+@include tablet {
+  .banner-text {
+    font-size: 3.5rem;
+  }
+}
+@include desktop {
+  .banner-text {
+    font-size: 4rem;
   }
 }

--- a/src/pages/PostUploadPage/PostUploadPage.scss
+++ b/src/pages/PostUploadPage/PostUploadPage.scss
@@ -7,13 +7,20 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: space-between;
-  padding: 4rem 0;
+  align-items: center;
+  padding: 1.5rem 0.5rem;
   border: 1px solid $gray-border-color;
+}
 
-  .btns {
-    display: flex;
-    justify-content: space-around;
+.btns {
+  display: flex;
+  justify-content: space-around;
+}
+
+@include tablet-and-desktop {
+  .wrapper {
+    padding: 4rem 0;
+    width: auto;
   }
 }

--- a/src/pages/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfileEditPage/ProfileEditPage.jsx
@@ -1,20 +1,21 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import classNames from 'classnames/bind';
+import FadeLoader from 'react-spinners/FadeLoader';
+import { css } from '@emotion/core';
 import styles from './ProfileEditPage.scss';
+import CommonPost from '../../components/CommonPost/CommonPost';
+import CommonBtn from '../../components/CommonBtn/CommonBtn';
 import Header from '../../components/Header/Header';
 import ProfileImage from '../../components/ProfileImage/ProfileImage';
 import ProfileContentItem from '../../components/ProfileContentItem/ProfileContentItem';
+import ProfileImageChangeBtn from './ProfileImageChangeBtn';
 import useInput from '../../hooks/useInput';
 import useFetch from '../../hooks/useFetch';
-import { WEB_SERVER_URL, MAIN_COLOR } from '../../configs';
-import { css } from '@emotion/core';
-import FadeLoader from 'react-spinners/FadeLoader';
-import CommonBtn from '../../components/CommonBtn/CommonBtn';
-import ProfileImageChangeBtn from './ProfileImageChangeBtn';
 import useScript from '../../hooks/useScript';
 import useS3 from '../../hooks/useS3';
 import { debounce } from '../../utils/utils';
 import { useLoginContext } from '../../contexts/LoginContext';
+import { WEB_SERVER_URL, MAIN_COLOR } from '../../configs';
 
 const cx = classNames.bind(styles);
 
@@ -225,8 +226,8 @@ const ProfileEditPage = () => {
   return (
     <>
       <Header />
-      <div className={cx('dimmed-background')}>
-        <div className={cx('wrapper')}>
+      <CommonPost.background className={cx('background')}>
+        <CommonPost className={cx('wrapper')}>
           <div className={cx('nav')}>
             <div className={cx('nav-item')}>프로필 편집</div>
           </div>
@@ -240,7 +241,11 @@ const ProfileEditPage = () => {
           {!loading && (
             <form className={cx('content-form')}>
               <div className={cx('profile-image-section')}>
-                <ProfileImage large src={imageSrc} />
+                <ProfileImage
+                  large
+                  src={imageSrc}
+                  className={cx('profile-image')}
+                />
                 <ProfileImageChangeBtn
                   setImage={setImage}
                   setInitialPageEnter={setInitialPageEnter}
@@ -282,8 +287,8 @@ const ProfileEditPage = () => {
               </CommonBtn>
             </form>
           )}
-        </div>
-      </div>
+        </CommonPost>
+      </CommonPost.background>
     </>
   );
 };

--- a/src/pages/ProfileEditPage/ProfileEditPage.scss
+++ b/src/pages/ProfileEditPage/ProfileEditPage.scss
@@ -1,35 +1,76 @@
 @import '../../stylesheets/util.scss';
 
-.dimmed-background {
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  top: 0px;
-  left: 0px;
-  background-color: $gray-background-color;
-}
+$edit-page-tablet-width: 50rem;
 
 .wrapper {
   display: flex;
-  justify-content: space-between;
-  position: relative;
-  margin: 13rem auto 0 auto;
-  padding: 10rem 10rem 8rem 10rem;
-  width: 100rem;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
   border: 1px solid $gray-border-color;
   background-color: #fff;
+}
+
+.nav-item {
+  padding: 1rem;
+  width: 99vw;
+  border-left: 3px solid $main-color;
+  font-size: 1.6rem;
+  text-align: center;
+  font-weight: bold;
+  color: $main-color;
+}
+
+.content-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  width: 100vw;
+}
+
+.profile-image-section {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  height: 20rem;
+}
+
+.submit-btn {
+  width: 100%;
+  margin: 3rem 0 2rem 0;
+
+  span {
+    font-size: 1.6rem;
+  }
+}
+
+@include tablet {
+  .wrapper {
+    max-width: $edit-page-tablet-width;
+  }
+  .nav-item {
+    max-width: $edit-page-tablet-width;
+  }
+  .content-form {
+    max-width: $edit-page-tablet-width;
+  }
+}
+
+@include desktop {
+  .wrapper {
+    flex-direction: row;
+    padding: 10rem 10rem 8rem 10rem;
+    width: 100rem;
+    height: 65rem;
+  }
 
   .nav {
     width: 20%;
-
-    &-item {
-      text-align: center;
-      padding: 1rem;
-      font-size: 1.6rem;
-      border-left: 3px solid $main-color;
-      font-weight: bold;
-      color: $main-color;
-    }
+  }
+  .nav-item {
+    width: 100%;
   }
 
   .content-form {
@@ -38,18 +79,15 @@
 
   .profile-image-section {
     display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    margin: 0 2rem 2rem 18rem;
+    flex-direction: row;
+    justify-content: center;
+    padding-left: 2rem;
   }
-
+  .profile-image {
+    margin-right: 2rem;
+  }
   .submit-btn {
-    position: absolute;
-    right: 1rem;
-    bottom: 1rem;
-
-    span {
-      font-size: 1.6rem;
-    }
+    align-self: flex-end;
+    width: 15%;
   }
 }

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -1,23 +1,25 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
+import { useHistory } from 'react-router-dom';
 import classNames from 'classnames/bind';
+import FadeLoader from 'react-spinners/FadeLoader';
+import { css } from '@emotion/core';
 import styles from './SignupPage.scss';
 import CommonBtn from '../../components/CommonBtn/CommonBtn';
 import CommonLink from '../../components/CommonLink/CommonLink';
-import useInput from '../../hooks/useInput';
-import { css } from '@emotion/core';
-import FadeLoader from 'react-spinners/FadeLoader';
-import { debounce } from '../../utils/utils';
-import { WEB_SERVER_URL, MAIN_COLOR } from '../../configs';
+import ValidityMessage from '../../components/ValidityMessage/ValidityMessage';
 import { useLoginContext } from '../../contexts/LoginContext';
 import useTempTokenValidation from '../../hooks/useTempTokenValidation';
 import useShakeAnimation from '../../hooks/useShakeAnimation';
-import ValidityMessage from '../../components/ValidityMessage/ValidityMessage';
-import { useHistory } from 'react-router-dom';
+import useMediaQuerySet from '../../hooks/useMediaQuerySet';
+import useInput from '../../hooks/useInput';
+import { debounce } from '../../utils/utils';
+import { WEB_SERVER_URL, MAIN_COLOR, IMAGE_BUCKET_URL } from '../../configs';
 
 const cx = classNames.bind(styles);
 
 const SignupPage = () => {
   const history = useHistory();
+  const { isMobile } = useMediaQuerySet();
   const { setLoggedIn, setNeedsUserInfo } = useLoginContext();
   const { inputValue, handleChange } = useInput();
   const { nickname } = inputValue;
@@ -89,6 +91,7 @@ const SignupPage = () => {
     });
     const json = await res.json();
     const domainRegExp = /^(((http(s?)):\/\/)?)([0-9a-zA-Z-]+(\.|:))([a-z]{2,3}|[0-9]{4})/;
+
     //사용자가 회원가입 하기 이전에 보고 있던 페이지 url
     const referer = json.referer.replace(domainRegExp, '');
     switch (res.status) {
@@ -137,7 +140,6 @@ const SignupPage = () => {
       {!loading && (
         <div className={cx('main')}>
           <h2>{provider} 회원가입</h2>
-          <div className={cx('auth-checker')}>인증완료</div>
           <span>닉네임을 만들어주세요</span>
           <div ref={shakeTarget} className={cx('input-section')}>
             <input

--- a/src/pages/SignupPage/SignupPage.scss
+++ b/src/pages/SignupPage/SignupPage.scss
@@ -10,73 +10,95 @@
     align-items: center;
     width: 100vw;
     height: $header-height;
-    padding: 0 5rem;
+    padding: 0 3rem;
     border-bottom: 1px solid $gray-border-color;
 
     > a > h1 {
       color: $main-color;
-      font-size: 6rem;
+      font-size: 4rem;
       font-weight: bold;
       font-family: 'godoMaum';
-      white-space: nowrap;
-      &:hover {
-        color: $main-color-light;
+    }
+  }
+}
+.main {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  height: 60vh;
+
+  > h2 {
+    margin-bottom: 2rem;
+    font-size: $large-title-font-size;
+  }
+
+  > span {
+    margin-bottom: 3rem;
+    font-size: $small-title-font-size;
+  }
+}
+
+.input-section {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 5rem;
+  width: 100%;
+
+  > input {
+    width: 100%;
+    height: 5rem;
+    padding: 0.5rem 1rem;
+    font-size: 2rem;
+    border: 1px solid $gray-border-color;
+    border-radius: 5px;
+
+    &:hover {
+      border: 1px solid #333;
+    }
+    &:focus {
+      outline: none;
+    }
+    &::placeholder {
+      color: $gray-font-color;
+    }
+  }
+}
+
+.signup-btn {
+  width: 100%;
+  > span {
+    font-size: 2rem;
+  }
+}
+
+@include tablet-and-desktop {
+  .wrapper {
+    header {
+      padding: 0 5rem;
+      > a > h1 {
+        font-size: 6rem;
+        &:hover {
+          color: $main-color-light;
+        }
       }
     }
   }
-
   .main {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
     height: calc(100vh - #{$header-height});
 
     > h2 {
-      margin-bottom: 2rem;
       font-size: 5rem;
     }
-
-    > span {
-      margin-bottom: 3rem;
-      font-size: 3rem;
-    }
   }
-  .auth-checker {
-    margin-bottom: 4rem;
-    font-size: 2rem;
-    color: violet;
-  }
-
   .input-section {
-    position: relative;
-    display: flex;
-    align-items: center;
-    margin-bottom: 5rem;
-
     > input {
       width: 45rem;
-      height: 5rem;
-      padding: 0.5rem 1rem;
-      font-size: 2rem;
-      border: 1px solid $gray-border-color;
-      border-radius: 5px;
-
-      &:hover {
-        border: 1px solid #333;
-      }
-      &:focus {
-        outline: none;
-      }
-      &::placeholder {
-        color: $gray-font-color;
-      }
     }
   }
-
   .signup-btn {
-    > span {
-      font-size: 2rem;
-    }
+    width: auto;
   }
 }

--- a/src/stylesheets/util.scss
+++ b/src/stylesheets/util.scss
@@ -24,3 +24,24 @@ $gray-font-color: #bdbdbd;
 $dark-gray-font-color: #616161;
 
 $header-height: 8rem;
+
+$breakpoint-tablet: 768px;
+$breakpoint-desktop: 1200px;
+
+@mixin tablet {
+  @media (min-width: #{$breakpoint-tablet}) and (max-width: #{$breakpoint-desktop - 1px}) {
+    @content;
+  }
+}
+
+@mixin desktop {
+  @media (min-width: #{$breakpoint-desktop}) {
+    @content;
+  }
+}
+
+@mixin tablet-and-desktop {
+  @media (min-width: #{$breakpoint-tablet}) {
+    @content;
+  }
+}

--- a/src/stylesheets/util.scss
+++ b/src/stylesheets/util.scss
@@ -25,6 +25,10 @@ $dark-gray-font-color: #616161;
 
 $header-height: 8rem;
 
+$small-title-font-size: 2rem;
+$medium-title-font-size: 2.75rem;
+$large-title-font-size: 3.5rem;
+
 $breakpoint-tablet: 768px;
 $breakpoint-desktop: 1200px;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,6 +2193,11 @@ css-loader@^3.2.0:
     postcss-value-parser "^4.0.2"
     schema-utils "^2.6.0"
 
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+  integrity sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=
+
 css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -3602,6 +3607,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+hyphenate-style-name@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
+  integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -4328,6 +4338,13 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+matchmediaquery@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.3.1.tgz#8247edc47e499ebb7c58f62a9ff9ccf5b815c6d7"
+  integrity sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==
+  dependencies:
+    css-mediaquery "^0.1.2"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -5588,6 +5605,16 @@ react-overlays@^2.1.0:
     uncontrollable "^7.0.0"
     warning "^4.0.3"
 
+react-responsive@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-8.0.3.tgz#ceb84205359b6032d306650e51490dc1f63d907b"
+  integrity sha512-F9VXyLao7O8XHXbLjQbIr4+mC6Zr0RDTwNjd7ixTmYEAyKyNanBkLkFchNaMZgszoSK6PgSs/3m/QDWw33/gpg==
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.3.0"
+    prop-types "^15.6.1"
+    shallow-equal "^1.1.0"
+
 react-router-dom@^5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
@@ -6182,6 +6209,11 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
+
+shallow-equal@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shallowequal@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
### 구현사항
- 반응형 웹 적용
- TitleUploader의 '누구랑' 부분에 select 엘리먼트 대신 input 엘리먼트가 기본적으로 나오도록 개선

<img width="600" alt="스크린샷 2020-02-18 오전 11 21 30" src="https://user-images.githubusercontent.com/42905468/74698358-d3062000-5240-11ea-956e-21b2807d525f.png">


### 참고사항
- 일단 모바일에서도 모든 기능에 접근 가능한 것을 목적으로 작업했어요.
- 모바일에서의 사용성은 계속 고민해서 UI/UX를 개선해 나가야 할 것 같아요.
- 다른 페이지에서 비슷한 레이아웃을 가지는 경우에는 가능하면 컴포넌트를 통일하려고 했어요.(Modal, CommonPost)
- sass 문법으로 css class nesting을 많이 사용했는데 미디어쿼리를 적용할 때는 조금 번거로워서 nesting을 많이 해제했어요. nesting이 없어지면서 css만 보더라도 구조가 눈에 들어온다는 장점은 사라졌지만 nesting이 여러번 적용된 클래스에 미디어쿼리를 적용하는 건 상대적으로 수월해지는 장점이 생겼어요.
- 전체적으로 css를 손보면서 느낀건데, 중복이 많으면 확실히 코드가 쉽게 깨지더라구요. 비슷한 모양의 버튼이 여러군데에 있는데 css가 제각각 정의되어있으면 일일히 찾아가면서 수정해줘야해서 번거롭고, 더 중요한건 수정해야하는 부분이 또 있을지 없을지 모른다는 점이 불안했어요. 코드의 재사용이라는 측면에서 뿐만 아니라, 유지보수의 용이성이라는 측면에서도 중복을 줄이는게 좋겠다는 생각을 했습니다.

### 해결된 이슈 번호
- resolved #107 
- resolved #97 
