### PR TITLE
[57] MainPage lazy-loading 적용

### DIFF
--- a/src/components/PostItem/PostImage.jsx
+++ b/src/components/PostItem/PostImage.jsx
@@ -34,6 +34,11 @@ const PostImage = ({ headerOn, src }) => {
             className={cx('img', 'thumb')}
             style={{ opacity: isLoaded ? 0 : 1 }}
           />
+          {!isLoaded && (
+            <div className={cx('bar')}>
+              <div className={cx('indicator')} />
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/components/PostItem/PostImage.jsx
+++ b/src/components/PostItem/PostImage.jsx
@@ -6,18 +6,11 @@ import styles from './PostImage.scss';
 const cx = classNames.bind(styles);
 
 const PostImage = ({ headerOn, src }) => {
-  const [isVisible, setIsVisible] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
   const target = useRef(null);
 
-  useIntersectionObserver({
+  const [isVisible] = useIntersectionObserver({
     target,
-    onIntersect: ([{ isIntersecting }], observer) => {
-      if (isIntersecting) {
-        setIsVisible(true);
-        observer.unobserve(target.current);
-      }
-    },
   });
   return (
     <div className={cx('wrapper')} ref={target}>

--- a/src/components/PostItem/PostImage.jsx
+++ b/src/components/PostItem/PostImage.jsx
@@ -1,0 +1,43 @@
+import React, { useRef, useState } from 'react';
+import classNames from 'classnames/bind';
+import useIntersectionObserver from '../../hooks/useIntersectionObserver';
+import styles from './PostImage.scss';
+
+const cx = classNames.bind(styles);
+
+const PostImage = ({ headerOn, src }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const target = useRef(null);
+
+  useIntersectionObserver({
+    target,
+    onIntersect: ([{ isIntersecting }], observer) => {
+      if (isIntersecting) {
+        setIsVisible(true);
+        observer.unobserve(target.current);
+      }
+    },
+  });
+  return (
+    <div className={cx('wrapper')} ref={target}>
+      {isVisible && (
+        <>
+          <img
+            style={{ opacity: isLoaded ? 1 : 0 }}
+            onLoad={() => setIsLoaded(true)}
+            className={cx('img', 'full', headerOn ? '' : 'without-header')}
+            src={src}
+            alt="representative post image"
+          />
+          <img
+            className={cx('img', 'thumb')}
+            style={{ opacity: isLoaded ? 0 : 1 }}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PostImage;

--- a/src/components/PostItem/PostImage.scss
+++ b/src/components/PostItem/PostImage.scss
@@ -20,11 +20,49 @@
 }
 
 .full {
-  transition: opacity 0s ease 0.5s;
+  transition: opacity 0.5s ease 0s;
 }
 .thumb {
   filter: blur(20px);
   transform: scale(1.1);
-  transition: opacity 1s ease 0s;
-  background-color: #aaaaaa; //TODO: 썸네일 기능 구현 시 삭제.
+}
+
+.bar {
+  width: 100%;
+  position: absolute;
+  animation: skeleton 1s ease-in infinite;
+}
+
+.indicator {
+  width: 0;
+  box-shadow: 0 0 75px 75px white;
+}
+
+.bar,
+.indicator {
+  height: 100%;
+}
+
+@keyframes skeleton {
+  0% {
+    transform: translateX(0);
+    opacity: 0;
+  }
+
+  20% {
+    opacity: 0.25;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  80% {
+    opacity: 0.5;
+  }
+
+  100% {
+    transform: translateX(100%);
+    opacity: 0;
+  }
 }

--- a/src/components/PostItem/PostImage.scss
+++ b/src/components/PostItem/PostImage.scss
@@ -1,0 +1,30 @@
+.wrapper {
+  position: relative;
+  padding-bottom: 100%;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background-color: #eeeeee;
+}
+
+.img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.without-header {
+  border-radius: 5px 5px 0 0;
+}
+
+.full {
+  transition: opacity 0s ease 0.5s;
+}
+.thumb {
+  filter: blur(20px);
+  transform: scale(1.1);
+  transition: opacity 1s ease 0s;
+  background-color: #aaaaaa; //TODO: 썸네일 기능 구현 시 삭제.
+}

--- a/src/components/PostItem/PostItem.jsx
+++ b/src/components/PostItem/PostItem.jsx
@@ -4,6 +4,7 @@ import ProfileImage from '../ProfileImage/ProfileImage';
 import CommonLink from '../CommonLink/CommonLink';
 import { profilePage } from '../../utils/utils';
 import styles from './PostItem.scss';
+import PostImage from './PostImage';
 
 const cx = classNames.bind(styles);
 
@@ -29,11 +30,7 @@ const PostItem = ({
           </CommonLink>
         </div>
       )}
-      <img
-        className={cx(headerOn ? 'img' : 'img-without-header')}
-        src={image}
-        alt="representative post image"
-      />
+      <PostImage src={image} headerOn={headerOn} />
       <div className={cx('title')}>
         {place}에서 {companion} {activity}
       </div>

--- a/src/components/PostItem/PostItem.scss
+++ b/src/components/PostItem/PostItem.scss
@@ -31,17 +31,6 @@
     }
   }
 
-  .img {
-    width: 100%;
-    height: 100%;
-  }
-
-  .img-without-header {
-    width: 100%;
-    height: 100%;
-    border-radius: 5px 5px 0 0;
-  }
-
   .title {
     padding: 1rem 1.5rem 0 1.5rem;
     font-size: 1.6rem;

--- a/src/hooks/useIntersectionObserver.jsx
+++ b/src/hooks/useIntersectionObserver.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const useIntersectionObserver = ({
   target,
@@ -7,12 +7,23 @@ const useIntersectionObserver = ({
   rootMargin = '0px',
   threshold = 0.1,
 }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const onIntersectDefault = ([{ isIntersecting }], observer) => {
+    if (isIntersecting) {
+      setIsVisible(true);
+      observer.unobserve(target.current);
+    }
+  };
   useEffect(() => {
-    const observer = new IntersectionObserver(onIntersect, {
-      root,
-      rootMargin,
-      threshold,
-    });
+    const observer = new IntersectionObserver(
+      onIntersect || onIntersectDefault,
+      {
+        root,
+        rootMargin,
+        threshold,
+      }
+    );
 
     const targetElement = target.current;
     observer.observe(targetElement);
@@ -21,6 +32,7 @@ const useIntersectionObserver = ({
       observer.unobserve(targetElement);
     };
   }, []);
+  return [isVisible];
 };
 
 export default useIntersectionObserver;

--- a/src/hooks/useIntersectionObserver.jsx
+++ b/src/hooks/useIntersectionObserver.jsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+const useIntersectionObserver = ({
+  target,
+  onIntersect,
+  root,
+  rootMargin = '0px',
+  threshold = 0.1,
+}) => {
+  useEffect(() => {
+    const observer = new IntersectionObserver(onIntersect, {
+      root,
+      rootMargin,
+      threshold,
+    });
+
+    const targetElement = target.current;
+    observer.observe(targetElement);
+
+    return () => {
+      observer.unobserve(targetElement);
+    };
+  }, []);
+};
+
+export default useIntersectionObserver;


### PR DESCRIPTION
### 구현내용
- MainPage에서 불러오는 post 이미지에 대해 지연로딩 적용
  - S3 트래픽 감소 및 클라이언트 성능향상
- 로직 재사용을 위해 useIntersectionObserver hook 작성

### 참고사항
- 프로필 페이지에서 보여지는 post 이미지에도 동일하게 적용됩니다.(같은 컴포넌트)

### 해결된 이슈 번호
- resolved #121 
