### PR TITLE
[58] 모든 페이지에 dynamic import 적용

### DIFF
--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -3,6 +3,7 @@ import React, { lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import MainPage from './pages/MainPage/MainPage';
 import LoginContextProvider from './contexts/LoginContext';
+import Loader from './components/Loader';
 
 const ProfileEditPage = lazy(() =>
   import(/* webpackChunkName: "profile-edit-page" */ './pages/ProfileEditPage')
@@ -24,7 +25,7 @@ const Root = () => {
   return (
     <Router>
       <LoginContextProvider>
-        <Suspense fallback={<div>loading...</div>}>
+        <Suspense fallback={<Loader size={50} unit={'px'} />}>
           <Switch>
             <Route exact path="/" component={MainPage} />
             <Route path="/profile/edit" component={ProfileEditPage} />

--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -1,27 +1,40 @@
 import { hot } from 'react-hot-loader/root';
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import MainPage from './pages/MainPage/MainPage';
-import DetailPage from './pages/DetailPage/DetailPage';
-import ProfileEditPage from './pages/ProfileEditPage/ProfileEditPage';
-import ProfilePage from './pages/ProfilePage/ProfilePage';
-import PostUploadPage from './pages/PostUploadPage/PostUploadPage';
-import SignupPage from './pages/SignupPage/SignupPage';
 import LoginContextProvider from './contexts/LoginContext';
+
+const ProfileEditPage = lazy(() =>
+  import(/* webpackChunkName: "profile-edit-page" */ './pages/ProfileEditPage')
+);
+const ProfilePage = lazy(() =>
+  import(/* webpackChunkName: "profile-page" */ './pages/ProfilePage')
+);
+const PostUploadPage = lazy(() =>
+  import(/* webpackChunkName: "post-upload-page" */ './pages/PostUploadPage')
+);
+const DetailPage = lazy(() =>
+  import(/* webpackChunkName: "detail-page" */ './pages/DetailPage')
+);
+const SignupPage = lazy(() =>
+  import(/* webpackChunkName: "signup-page" */ './pages/SignupPage')
+);
 
 const Root = () => {
   return (
     <Router>
       <LoginContextProvider>
-        <Switch>
-          <Route exact path="/" component={MainPage} />
-          <Route path="/profile/edit" component={ProfileEditPage} />
-          <Route path="/profile" component={ProfilePage} />
-          <Route path="/post/upload" component={() => <PostUploadPage />} />
-          <Route path="/post/edit" component={() => <PostUploadPage />} />
-          <Route path="/post/:postId" component={DetailPage} />
-          <Route path="/signup" component={SignupPage} />
-        </Switch>
+        <Suspense fallback={<div>loading...</div>}>
+          <Switch>
+            <Route exact path="/" component={MainPage} />
+            <Route path="/profile/edit" component={ProfileEditPage} />
+            <Route path="/profile" component={ProfilePage} />
+            <Route path="/post/upload" component={() => <PostUploadPage />} />
+            <Route path="/post/edit" component={() => <PostUploadPage />} />
+            <Route path="/post/:postId" component={DetailPage} />
+            <Route path="/signup" component={SignupPage} />
+          </Switch>
+        </Suspense>
       </LoginContextProvider>
     </Router>
   );

--- a/src/components/Loader/Loader.jsx
+++ b/src/components/Loader/Loader.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import styles from './Loader.scss';
+
+const cx = classNames.bind(styles);
+
+const Loader = ({ size, unit }) => {
+  return (
+    <div className={cx('wrapper', 'center')}>
+      <div
+        className={cx('loader')}
+        style={{ width: `${size}${unit}`, height: `${size}${unit}` }}
+      />
+    </div>
+  );
+};
+
+export default Loader;

--- a/src/components/Loader/Loader.scss
+++ b/src/components/Loader/Loader.scss
@@ -1,0 +1,25 @@
+@import '../../stylesheets/util.scss';
+
+.wrapper {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+}
+.loader {
+  border: 3px solid $main-color-light;
+  border-radius: 50%;
+  border-top-color: $main-color;
+  animation: spin 1s ease-in-out infinite;
+}
+
+.center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Loader/index.js
+++ b/src/components/Loader/index.js
@@ -1,0 +1,1 @@
+export { default } from './Loader';

--- a/src/pages/DetailPage/DetailPage.jsx
+++ b/src/pages/DetailPage/DetailPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import { css } from '@emotion/core';
 import FadeLoader from 'react-spinners/FadeLoader';
@@ -22,7 +22,7 @@ const DetailPage = () => {
   const { data, loading } = useFetch({
     onRequest: () => api.getPostDetail(postId),
     watch: postId,
-    loadStatus: true
+    loadStatus: true,
   });
 
   return (

--- a/src/pages/DetailPage/index.js
+++ b/src/pages/DetailPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './DetailPage';

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import classNames from 'classnames/bind';
 import styles from './MainPage.scss';
 import Header from '../../components/Header/Header';
-import PostContainer from '../../components/PostContainer/PostContainer';
 
 const cx = classNames.bind(styles);
+
+const PostContainer = lazy(() =>
+  import(
+    /* webpackChunkName: "post-container" */ '../../components/PostContainer/PostContainer'
+  )
+);
 
 const MainPage = () => {
   return (
@@ -17,7 +22,9 @@ const MainPage = () => {
           <br /> 그리고 개인의 취향에 따라 할 일을 추천합니다.
         </div>
       </div>
-      <PostContainer headerOn />
+      <Suspense fallback={<div>loading...</div>}>
+        <PostContainer headerOn />
+      </Suspense>
     </div>
   );
 };

--- a/src/pages/MainPage/index.js
+++ b/src/pages/MainPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './MainPage';

--- a/src/pages/PostUploadPage/PostUploadPage.jsx
+++ b/src/pages/PostUploadPage/PostUploadPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useReducer } from 'react';
+import React, { useEffect, useMemo, useReducer } from 'react';
 import { useHistory, useLocation, Prompt } from 'react-router-dom';
 import classNames from 'classnames/bind';
 import styles from './PostUploadPage.scss';

--- a/src/pages/PostUploadPage/index.js
+++ b/src/pages/PostUploadPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './PostUploadPage';

--- a/src/pages/ProfileEditPage/index.js
+++ b/src/pages/ProfileEditPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProfileEditPage';

--- a/src/pages/ProfilePage/index.js
+++ b/src/pages/ProfilePage/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProfilePage';

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import classNames from 'classnames/bind';
 import FadeLoader from 'react-spinners/FadeLoader';
@@ -39,9 +39,9 @@ const SignupPage = () => {
     setNicknameAlreadyInUse,
     setNicknameHasBlanks,
     setValidationServerError,
-    showNicknameInfoMessage
+    showNicknameInfoMessage,
   } = useProfileValidation({
-    nickname: { isValid: false, message: '' }
+    nickname: { isValid: false, message: '' },
   });
 
   const { request: checkNicknameFromServer } = useFetch({
@@ -50,11 +50,11 @@ const SignupPage = () => {
     onError: {
       400: setNicknameHasBlanks,
       409: setNicknameAlreadyInUse,
-      500: setValidationServerError
-    }
+      500: setValidationServerError,
+    },
   });
 
-  const checkNicknameValidation = useDebounce(nickname => {
+  const checkNicknameValidation = useDebounce((nickname) => {
     if (!nickname) return resetValidation();
 
     const isValid = /^[A-Za-z][A-Za-z0-9_-]{3,14}$/.test(nickname);
@@ -86,12 +86,12 @@ const SignupPage = () => {
       401: () => {
         shakeInput();
         setInvalidToken();
-      }
-    }
+      },
+    },
   });
-  const goTo = prevPath => {
+  const goTo = (prevPath) => {
     setLoggedIn(true);
-    setNeedsUserInfo(state => !state);
+    setNeedsUserInfo((state) => !state);
     history.push(prevPath);
   };
 

--- a/src/pages/SignupPage/index.js
+++ b/src/pages/SignupPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './SignupPage';


### PR DESCRIPTION
### 구현사항
- 페이지 컴포넌트에 dynamic import 적용
- 메인 페이지는 포스트 목록 부분만 적용
  - 제일 처음 보여지는 헤더와 배너 부분은 나눠진 번들을 받아서 보여주기보단 메인 번들에 포함된게 낫다고 판단.

### 해결된 이슈 번호
- resolved #123 
